### PR TITLE
SSCS-2575 Unblock CCD callbacks to Notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,29 @@ To run all unit tests execute the following command:
 ```
 ./gradlew test
 ```
+
+### Debugging locally with CCD
+
+Setup callbacks by finding out IP address:
+```
+ifconfig
+```
+Copy the inet value from en0 and place this value in the callback column in the definition spreadsheet.
+
+Start CCD application 
+```
+./compose-frontend.sh up -d
+```
+In IDE, start the application in Debug mode and put a breakpoint in the appropriate place. Then login to CCD and start an event which would trigger a callback.
+
+### Run locally in Docker with CCD using an alias
+
+Create an alias
+```
+alias run-notify='docker-compose -f compose/backend.yml -f compose/frontend.yml -f ../track-your-appeal-notifications/docker-compose.yml'
+```
+Run the alias
+```
+run-notify up -d
+```
+This starts the CCD applications with Track-your-appeal-notifications in Docker with just one command

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '3.0'
 
 services:
   track-your-appeal-notifications:

--- a/src/main/java/uk/gov/hmcts/sscs/domain/CcdResponse.java
+++ b/src/main/java/uk/gov/hmcts/sscs/domain/CcdResponse.java
@@ -2,84 +2,26 @@ package uk.gov.hmcts.sscs.domain;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import uk.gov.hmcts.sscs.deserialize.CcdResponseDeserializer;
-import uk.gov.hmcts.sscs.domain.notify.Destination;
 import uk.gov.hmcts.sscs.domain.notify.NotificationType;
 
 @JsonDeserialize(using = CcdResponseDeserializer.class)
 public class CcdResponse {
 
-    private String appellantFirstName;
-    private String appellantSurname;
-    private String appellantTitle;
-    private String appealNumber;
     private String caseReference;
-    private String email;
-    private String mobileNumber;
+    private Subscription appellantSubscription;
+    private Subscription supporterSubscription;
     private NotificationType notificationType;
-
 
     public CcdResponse() {
         //
     }
 
-    public CcdResponse(String appellantFirstName, String appellantSurname, String appellantTitle, String appealNumber,
-                       String caseReference, String email, String mobileNumber, NotificationType notificationType) {
-        this.appellantFirstName = appellantFirstName;
-        this.appellantSurname = appellantSurname;
-        this.appellantTitle = appellantTitle;
-        this.appealNumber = appealNumber;
+    public CcdResponse(String caseReference, Subscription appellantSubscription, Subscription supporterSubscription,
+                       NotificationType notificationType) {
         this.caseReference = caseReference;
-        this.email = email;
-        this.mobileNumber = mobileNumber;
+        this.appellantSubscription = appellantSubscription;
+        this.supporterSubscription = supporterSubscription;
         this.notificationType = notificationType;
-    }
-
-    public String getAppellantFirstName() {
-        return appellantFirstName;
-    }
-
-    public void setAppellantFirstName(String appellantFirstName) {
-        this.appellantFirstName = appellantFirstName;
-    }
-
-    public String getAppellantSurname() {
-        return appellantSurname;
-    }
-
-    public void setAppellantSurname(String appellantSurname) {
-        this.appellantSurname = appellantSurname;
-    }
-
-    public String getAppealNumber() {
-        return appealNumber;
-    }
-
-    public void setAppealNumber(String appealNumber) {
-        this.appealNumber = appealNumber;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getMobileNumber() {
-        return mobileNumber;
-    }
-
-    public void setMobileNumber(String mobileNumber) {
-        this.mobileNumber = mobileNumber;
-    }
-
-    public String getAppellantTitle() {
-        return appellantTitle;
-    }
-
-    public void setAppellantTitle(String appellantTitle) {
-        this.appellantTitle = appellantTitle;
     }
 
     public String getCaseReference() {
@@ -90,22 +32,20 @@ public class CcdResponse {
         this.caseReference = caseReference;
     }
 
-    public Destination getDestination() {
-        return new Destination(email, mobileNumber);
+    public Subscription getAppellantSubscription() {
+        return appellantSubscription;
     }
 
-    @Override
-    public String toString() {
-        return "CcdResponse{"
-                + " appellantFirstName='" + appellantFirstName + '\''
-                + ", appellantSurname='" + appellantSurname + '\''
-                + ", appellantTitle='" + appellantTitle + '\''
-                + ", appealNumber='" + appealNumber + '\''
-                + ", caseReference='" + caseReference + '\''
-                + ", notificationType='" + notificationType + '\''
-                + ", email='" + email + '\''
-                + ", mobileNumber='" + mobileNumber + '\''
-                + '}';
+    public void setAppellantSubscription(Subscription appellantSubscription) {
+        this.appellantSubscription = appellantSubscription;
+    }
+
+    public Subscription getSupporterSubscription() {
+        return supporterSubscription;
+    }
+
+    public void setSupporterSubscription(Subscription supporterSubscription) {
+        this.supporterSubscription = supporterSubscription;
     }
 
     public NotificationType getNotificationType() {
@@ -114,5 +54,15 @@ public class CcdResponse {
 
     public void setNotificationType(NotificationType notificationType) {
         this.notificationType = notificationType;
+    }
+
+    @Override
+    public String toString() {
+        return "CcdResponse{"
+                + " caseReference='" + caseReference + '\''
+                + ", appellantSubscription=" + appellantSubscription
+                + ", supporterSubscription=" + supporterSubscription
+                + ", notificationType=" + notificationType
+                + '}';
     }
 }

--- a/src/main/java/uk/gov/hmcts/sscs/domain/Subscription.java
+++ b/src/main/java/uk/gov/hmcts/sscs/domain/Subscription.java
@@ -1,0 +1,113 @@
+package uk.gov.hmcts.sscs.domain;
+
+import uk.gov.hmcts.sscs.domain.notify.Destination;
+
+public class Subscription {
+
+    private String firstName;
+    private String surname;
+    private String title;
+    private String appealNumber;
+    private String email;
+    private String mobileNumber;
+    private Boolean subscribeSms;
+    private Boolean subscribeEmail;
+
+    public Subscription() {
+        //
+    }
+
+    public Subscription(String firstName, String surname, String title, String appealNumber, String email,
+                        String mobileNumber, Boolean subscribeSms, Boolean subscribeEmail) {
+        this.firstName = firstName;
+        this.surname = surname;
+        this.title = title;
+        this.appealNumber = appealNumber;
+        this.email = email;
+        this.mobileNumber = mobileNumber;
+        this.subscribeSms = subscribeSms;
+        this.subscribeEmail = subscribeEmail;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getAppealNumber() {
+        return appealNumber;
+    }
+
+    public void setAppealNumber(String appealNumber) {
+        this.appealNumber = appealNumber;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getMobileNumber() {
+        return mobileNumber;
+    }
+
+    public void setMobileNumber(String mobileNumber) {
+        this.mobileNumber = mobileNumber;
+    }
+
+    public Boolean isSubscribeSms() {
+        return subscribeSms;
+    }
+
+    public void setSubscribeSms(Boolean subscribeSms) {
+        this.subscribeSms = subscribeSms;
+    }
+
+    public Boolean isSubscribeEmail() {
+        return subscribeEmail;
+    }
+
+    public void setSubscribeEmail(Boolean subscribeEmail) {
+        this.subscribeEmail = subscribeEmail;
+    }
+
+    public Destination getDestination() {
+        return new Destination(email, mobileNumber);
+    }
+
+    @Override
+    public String toString() {
+        return "Subscription{"
+                + " firstName='" + firstName + '\''
+                + ", surname='" + surname + '\''
+                + ", title='" + title + '\''
+                + ", appealNumber='" + appealNumber + '\''
+                + ", email='" + email + '\''
+                + ", mobileNumber='" + mobileNumber + '\''
+                + ", subscribeSms='" + subscribeSms + '\''
+                + ", subscribeEmail='" + subscribeEmail + '\''
+                + '}';
+    }
+}

--- a/src/main/java/uk/gov/hmcts/sscs/domain/notify/NotificationType.java
+++ b/src/main/java/uk/gov/hmcts/sscs/domain/notify/NotificationType.java
@@ -2,7 +2,7 @@ package uk.gov.hmcts.sscs.domain.notify;
 
 
 public enum NotificationType {
-    APPEAL_RECEIVED("appealReceivedNotification", 1, true);
+    APPEAL_RECEIVED("appealReceived", 1, true);
 
     private String id;
     private final int order;

--- a/src/main/java/uk/gov/hmcts/sscs/domain/notify/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/sscs/domain/notify/Personalisation.java
@@ -21,10 +21,10 @@ public abstract class Personalisation {
         personalisation.put(BENEFIT_NAME_ACRONYM_LITERAL, BENEFIT_NAME_ACRONYM);
         personalisation.put(BENEFIT_FULL_NAME_LITERAL, BENEFIT_FULL_NAME);
         personalisation.put(APPEAL_REF, ccdResponse.getCaseReference());
-        personalisation.put(APPEAL_ID, ccdResponse.getAppealNumber());
-        personalisation.put(APPELLANT_NAME, String.format("%s %s", ccdResponse.getAppellantFirstName(), ccdResponse.getAppellantSurname()));
+        personalisation.put(APPEAL_ID, ccdResponse.getAppellantSubscription().getAppealNumber());
+        personalisation.put(APPELLANT_NAME, String.format("%s %s", ccdResponse.getAppellantSubscription().getFirstName(), ccdResponse.getAppellantSubscription().getSurname()));
         personalisation.put(PHONE_NUMBER, config.getHmctsPhoneNumber());
-        personalisation.put(TRACK_APPEAL_LINK_LITERAL, config.getTrackAppealLink() != null ? config.getTrackAppealLink().replace(APPEAL_ID_LITERAL, ccdResponse.getAppealNumber()) : null);
+        personalisation.put(TRACK_APPEAL_LINK_LITERAL, config.getTrackAppealLink() != null ? config.getTrackAppealLink().replace(APPEAL_ID_LITERAL, ccdResponse.getAppellantSubscription().getAppealNumber()) : null);
 
         personalisation = customise(ccdResponse, personalisation);
         return personalisation;

--- a/src/main/java/uk/gov/hmcts/sscs/factory/NotificationFactory.java
+++ b/src/main/java/uk/gov/hmcts/sscs/factory/NotificationFactory.java
@@ -32,9 +32,9 @@ public class NotificationFactory {
         }
 
         Template template = personalisation.getTemplate();
-        Destination destination = ccdResponse.getDestination();
+        Destination destination = ccdResponse.getAppellantSubscription().getDestination();
         Reference reference = new Reference();
-        String appealNumber = ccdResponse.getAppealNumber();
+        String appealNumber = ccdResponse.getAppellantSubscription().getAppealNumber();
         return new Notification(template, destination, placeholders, reference, appealNumber);
     }
 }

--- a/src/test/java/uk/gov/hmcts/sscs/controller/NotificationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/controller/NotificationControllerTest.java
@@ -38,7 +38,12 @@ public class NotificationControllerTest {
 
     @Test
     public void shouldReturnHttpStatusCode200ForTheCcdResponse() throws Exception {
-        String json = "{\"state\":\"ResponseRequested\",\"case_data\":{\"id\":{\"tya\":\"755TY68876\"},\"appellant\":{\"name\":{\"title\":\"Mr\",\"lastName\":\"Maloney\",\"firstName\":\"J\"},\"contact\":{\"email\":\"test@testing.com\",\"mobile\":\"01234556634\"}}}}";
+        String json = "{\"case_details\":{\"case_data\":{\"subscriptions\":{"
+                + "\"appellantSubscription\":{\"tya\":\"543212345\",\"email\":\"test@testing.com\",\"mobile\":\"01234556634\",\"reason\":null,\"subscribeSms\":\"No\",\"subscribeEmail\":\"Yes\"},"
+                + "\"supporterSubscription\":{\"tya\":\"232929249492\",\"email\":\"supporter@live.co.uk\",\"mobile\":\"07925289702\",\"reason\":null,\"subscribeSms\":\"Yes\",\"subscribeEmail\":\"No\"}},"
+                + "\"caseReference\":\"SC/1234/23\",\"appeal\":{"
+                + "\"appellant\":{\"name\":{\"title\":\"Mr\",\"lastName\":\"Vasquez\",\"firstName\":\"Dexter\",\"middleName\":\"Ali Sosa\"}},"
+                + "\"supporter\":{\"name\":{\"title\":\"Mrs\",\"lastName\":\"Wilder\",\"firstName\":\"Amber\",\"middleName\":\"Clark Eaton\"}}}}},\"event_id\": \"appealReceived\"\n}";
 
         mockMvc.perform(post("/send")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/uk/gov/hmcts/sscs/factory/NotificationFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/factory/NotificationFactoryTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import uk.gov.hmcts.sscs.domain.CcdResponse;
+import uk.gov.hmcts.sscs.domain.Subscription;
 import uk.gov.hmcts.sscs.domain.notify.Notification;
 import uk.gov.hmcts.sscs.domain.notify.Template;
 import uk.gov.hmcts.sscs.placeholders.AppealReceivedPersonalisation;
@@ -30,8 +31,8 @@ public class NotificationFactoryTest {
     public void setup() {
         initMocks(this);
         factory = new NotificationFactory(personalisationFactory);
-        ccdResponse = new CcdResponse("Ronnie","Scott", "Mr", "ABC", "1234/5", "test@testing.com",
-                "07985858594", APPEAL_RECEIVED);
+        ccdResponse = new CcdResponse("SC/1234/5", new Subscription("Ronnie", "Scott", "Mr", "ABC",
+                "test@testing.com", "07985858594", true, false), null, APPEAL_RECEIVED);
     }
 
     @Test


### PR DESCRIPTION
- Receive callbacks from CCD
- Map CCD fields to Notification Subscriptions correctly
- Receive an Appellant and Supporter Notification details
- Ignore Supporter, assume notification is only sent to Appellant for MVP
- Updated Readme to provide instructions on debugging CCD callbacks with Notifications