### PR TITLE
SSCS-2576 Send Notification to gov notify

### DIFF
--- a/src/main/java/uk/gov/hmcts/sscs/TrackYourAppealNotificationsApplication.java
+++ b/src/main/java/uk/gov/hmcts/sscs/TrackYourAppealNotificationsApplication.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.sscs;
 import java.net.MalformedURLException;
 import java.util.TimeZone;
 import javax.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.MessageSource;
@@ -16,8 +17,8 @@ public class TrackYourAppealNotificationsApplication {
 
     public static final String UTC = "UTC";
 
-    //  @Value("${gov.uk.notification.api.key}")
-    private static final String apiKey = "test";
+    @Value("${gov.uk.notification.api.key}")
+    private String apiKey;
 
     @PostConstruct
     public void started() {

--- a/src/main/java/uk/gov/hmcts/sscs/config/AppConstants.java
+++ b/src/main/java/uk/gov/hmcts/sscs/config/AppConstants.java
@@ -10,6 +10,8 @@ public final class AppConstants {
     public static final String BENEFIT_FULL_NAME = "Employment Support Allowance";
     public static final String BENEFIT_NAME_ACRONYM_LITERAL = "benefit_name_acronym";
     public static final String BENEFIT_FULL_NAME_LITERAL = "benefit_full_name";
+    public static final String MAC_LITERAL = "mac";
+    public static final String MANAGE_EMAILS_LINK = "manage_emails_link";
     public static final String PHONE_NUMBER = "phone_number";
     public static final String TRACK_APPEAL_LINK_LITERAL = "track_appeal_link";
 

--- a/src/main/java/uk/gov/hmcts/sscs/config/NotificationConfig.java
+++ b/src/main/java/uk/gov/hmcts/sscs/config/NotificationConfig.java
@@ -7,6 +7,8 @@ import uk.gov.hmcts.sscs.domain.notify.Link;
 @Component
 public class NotificationConfig {
 
+    @Value("${manage.emails.link}")
+    private String manageEmailsLink;
     @Value("${hmcts.phone.number}")
     private String hmctsPhoneNumber;
     @Value("${track.appeal.link}")
@@ -14,6 +16,10 @@ public class NotificationConfig {
 
     public String getHmctsPhoneNumber() {
         return hmctsPhoneNumber;
+    }
+
+    public Link getManageEmailsLink() {
+        return new Link(manageEmailsLink);
     }
 
     public Link getTrackAppealLink() {

--- a/src/main/java/uk/gov/hmcts/sscs/domain/notify/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/sscs/domain/notify/Personalisation.java
@@ -24,6 +24,8 @@ public abstract class Personalisation {
         personalisation.put(APPEAL_ID, ccdResponse.getAppellantSubscription().getAppealNumber());
         personalisation.put(APPELLANT_NAME, String.format("%s %s", ccdResponse.getAppellantSubscription().getFirstName(), ccdResponse.getAppellantSubscription().getSurname()));
         personalisation.put(PHONE_NUMBER, config.getHmctsPhoneNumber());
+        //TODO: Replace hardcoded mactoken with an actual mac token
+        personalisation.put(MANAGE_EMAILS_LINK, config.getManageEmailsLink().replace(MAC_LITERAL, "Mactoken"));
         personalisation.put(TRACK_APPEAL_LINK_LITERAL, config.getTrackAppealLink() != null ? config.getTrackAppealLink().replace(APPEAL_ID_LITERAL, ccdResponse.getAppellantSubscription().getAppealNumber()) : null);
 
         personalisation = customise(ccdResponse, personalisation);

--- a/src/main/java/uk/gov/hmcts/sscs/placeholders/AppealReceivedPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/sscs/placeholders/AppealReceivedPersonalisation.java
@@ -1,7 +1,11 @@
 package uk.gov.hmcts.sscs.placeholders;
 
 import static com.google.common.collect.Maps.newHashMap;
+import static java.time.temporal.ChronoUnit.DAYS;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import uk.gov.hmcts.sscs.config.NotificationConfig;
 import uk.gov.hmcts.sscs.domain.CcdResponse;
@@ -13,8 +17,11 @@ public class AppealReceivedPersonalisation extends Personalisation {
 
     public static final String FIRST_TIER_AGENCY_ACRONYM = "first_tier_agency_acronym";
     public static final String FIRST_TIER_AGENCY_FULL_NAME = "first_tier_agency_full_name";
+    private static final String APPEAL_RESPOND_DATE = "appeal_respond_date";
     public static final String DWP_ACRONYM = "DWP";
     public static final String DWP_FUL_NAME = "Department for Work and Pensions";
+    private static final int MAX_DWP_RESPONSE_DAYS = 35;
+    private static final String RESPONSE_DATE_FORMAT = "dd MMMM yyyy";
 
     public AppealReceivedPersonalisation(NotificationConfig config) {
         super(config);
@@ -25,6 +32,12 @@ public class AppealReceivedPersonalisation extends Personalisation {
         Map<String, String> personalisation = newHashMap(defaultMap);
         personalisation.put(FIRST_TIER_AGENCY_ACRONYM, DWP_ACRONYM);
         personalisation.put(FIRST_TIER_AGENCY_FULL_NAME, DWP_FUL_NAME);
+
+        // TODO: Set this to the actual event date once event story has been implemented
+        ZonedDateTime z = ZonedDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneId.of("GMT"));
+
+        String dwpResponseDateString = z.plus(MAX_DWP_RESPONSE_DAYS, DAYS).format(DateTimeFormatter.ofPattern(RESPONSE_DATE_FORMAT));
+        personalisation.put(APPEAL_RESPOND_DATE, dwpResponseDateString);
 
         return personalisation;
     }

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -4,4 +4,8 @@ management.enabled=${MANAGEMENT_SECURITY_ENABLED:true}
 
 hmcts.phone.number=0300 123 1142
 
+manage.emails.link=${SSCS_MANAGE_EMAILS_LINK:http://localhost:3000/manage-email-notifications/mac}
 track.appeal.link=${SSCS_TRACK_YOUR_APPEAL_LINK:http://localhost:3000/progress/appeal_id/trackyourappeal}
+
+gov.uk.notification.api.key=${NOTIFICATION_API_KEY:emailnotificationkey}
+


### PR DESCRIPTION
- Add missing fields to allow an appeal received email to be sent to Gov Notify
- Hardcoded values which are dependent on other stories and added TODOs