### PR TITLE
SSCS-2743 Add event date to Personalisation

### DIFF
--- a/src/main/java/uk/gov/hmcts/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/sscs/personalisation/Personalisation.java
@@ -1,17 +1,17 @@
 package uk.gov.hmcts.sscs.personalisation;
 
-import static java.time.temporal.ChronoUnit.DAYS;
 import static uk.gov.hmcts.sscs.config.AppConstants.*;
 import static uk.gov.hmcts.sscs.domain.notify.EventType.SUBSCRIPTION_CREATED;
 
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import uk.gov.hmcts.sscs.config.NotificationConfig;
 import uk.gov.hmcts.sscs.domain.CcdResponse;
 import uk.gov.hmcts.sscs.domain.CcdResponseWrapper;
+import uk.gov.hmcts.sscs.domain.notify.Event;
 import uk.gov.hmcts.sscs.domain.notify.EventType;
 import uk.gov.hmcts.sscs.domain.notify.Template;
 import uk.gov.hmcts.sscs.service.MessageAuthenticationServiceImpl;
@@ -46,27 +46,58 @@ public class Personalisation {
 
         personalisation.put(FIRST_TIER_AGENCY_ACRONYM, DWP_ACRONYM);
         personalisation.put(FIRST_TIER_AGENCY_FULL_NAME, DWP_FUL_NAME);
-        // TODO: Set this to the actual event date once event story has been implemented
-        ZonedDateTime dwpResponseDate = ZonedDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneId.of("GMT"));
-        String dwpResponseDateString = formatDate(dwpResponseDate.plus(MAX_DWP_RESPONSE_DAYS, DAYS));
-        personalisation.put(APPEAL_RESPOND_DATE, dwpResponseDateString);
-        // TODO: Set this to the actual event date once event story has been implemented
-        ZonedDateTime evidenceReceivedDate = ZonedDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneId.of("GMT"));
-        String evidenceReceivedDateString = formatDate(evidenceReceivedDate);
-        personalisation.put(EVIDENCE_RECEIVED_DATE_LITERAL, evidenceReceivedDateString);
-        // TODO: Set this to the actual event date once event story has been implemented
-        ZonedDateTime z = ZonedDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneId.of("GMT"));
-        personalisation.put(HEARING_CONTACT_DATE, formatDate(z.plusWeeks(6)));
+
+        setEventData(personalisation, ccdResponse);
 
         return personalisation;
+    }
+
+    public Map<String, String> setEventData(Map<String, String> personalisation, CcdResponse ccdResponse) {
+        if (ccdResponse.getEvents() != null && !ccdResponse.getEvents().isEmpty()) {
+            Event event = ccdResponse.getEvents().get(0);
+
+            switch (event.getEventType()) {
+                case DWP_RESPONSE_RECEIVED : {
+                    String dwpResponseDateString = formatDate(addDays(event.getDate(), MAX_DWP_RESPONSE_DAYS));
+                    personalisation.put(APPEAL_RESPOND_DATE, dwpResponseDateString);
+                    setHearingContactDate(personalisation, event);
+                    break;
+                }
+                case EVIDENCE_RECEIVED : {
+                    personalisation.put(EVIDENCE_RECEIVED_DATE_LITERAL, formatDate(event.getDate()));
+                    break;
+                }
+                case POSTPONEMENT : {
+                    setHearingContactDate(personalisation, event);
+                    break;
+                }
+                default: break;
+            }
+        }
+        return personalisation;
+    }
+
+    private  Map<String, String> setHearingContactDate(Map<String, String> personalisation, Event event) {
+        String hearingContactDate = formatDate(addDays(event.getDate(), 42));
+        personalisation.put(HEARING_CONTACT_DATE, hearingContactDate);
+
+        return personalisation;
+    }
+
+    private static Date addDays(Date date, int days) {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(date);
+        cal.add(Calendar.DATE, days);
+        return cal.getTime();
     }
 
     public String getMacToken(String id) {
         return macService.generateToken(id);
     }
 
-    protected String formatDate(ZonedDateTime date) {
-        return date.format(DateTimeFormatter.ofPattern(RESPONSE_DATE_FORMAT));
+    protected String formatDate(Date date) {
+        SimpleDateFormat dt = new SimpleDateFormat(RESPONSE_DATE_FORMAT);
+        return dt.format(date);
     }
 
     public Template getTemplate(EventType type) {

--- a/src/test/java/uk/gov/hmcts/sscs/personalisation/PersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/personalisation/PersonalisationTest.java
@@ -4,9 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static uk.gov.hmcts.sscs.config.AppConstants.*;
-import static uk.gov.hmcts.sscs.domain.notify.EventType.DWP_RESPONSE_RECEIVED;
+import static uk.gov.hmcts.sscs.domain.notify.EventType.*;
 
-import java.util.Map;
+import java.util.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -14,6 +14,7 @@ import uk.gov.hmcts.sscs.config.NotificationConfig;
 import uk.gov.hmcts.sscs.domain.CcdResponse;
 import uk.gov.hmcts.sscs.domain.CcdResponseWrapper;
 import uk.gov.hmcts.sscs.domain.Subscription;
+import uk.gov.hmcts.sscs.domain.notify.Event;
 import uk.gov.hmcts.sscs.domain.notify.Link;
 import uk.gov.hmcts.sscs.service.MessageAuthenticationServiceImpl;
 
@@ -27,6 +28,8 @@ public class PersonalisationTest {
     @Mock
     private MessageAuthenticationServiceImpl macService;
 
+    Calendar c1;
+
     @Before
     public void setup() {
         initMocks(this);
@@ -37,14 +40,24 @@ public class PersonalisationTest {
         when(config.getEvidenceSubmissionInfoLink()).thenReturn(new Link("http://link.com/appeal_id"));
         when(config.getManageEmailsLink()).thenReturn(new Link("http://link.com/manage-email-notifications/mac"));
         when(macService.generateToken("GLSCRR")).thenReturn("ZYX");
+        c1 = GregorianCalendar.getInstance();
+        c1.set(2018, Calendar.JANUARY, 01);
     }
 
     @Test
     public void customisePersonalisation() {
+        Event event = new Event(c1.getTime(), DWP_RESPONSE_RECEIVED);
+
         Subscription appellantSubscription = new Subscription("Harry", "Kane", "Mr", "GLSCRR", "test@email.com",
                 "07983495065", true, false);
 
-        Map<String, String> result = personalisation.create(new CcdResponseWrapper(new CcdResponse("1234", appellantSubscription, null, DWP_RESPONSE_RECEIVED), null));
+        CcdResponse response = new CcdResponse("1234", appellantSubscription, null, DWP_RESPONSE_RECEIVED);
+        response.setEvents(new ArrayList() {{
+                add(event);
+            }
+        });
+
+        Map<String, String> result = personalisation.create(new CcdResponseWrapper(response, null));
 
         assertEquals(BENEFIT_NAME_ACRONYM, result.get(BENEFIT_NAME_ACRONYM_LITERAL));
         assertEquals(BENEFIT_FULL_NAME, result.get(BENEFIT_FULL_NAME_LITERAL));
@@ -56,9 +69,77 @@ public class PersonalisationTest {
         assertEquals("http://tyalink.com/GLSCRR", result.get(TRACK_APPEAL_LINK_LITERAL));
         assertEquals(DWP_ACRONYM, result.get(FIRST_TIER_AGENCY_ACRONYM));
         assertEquals(DWP_FUL_NAME, result.get(FIRST_TIER_AGENCY_FULL_NAME));
-        assertEquals("05 February 1900", result.get(APPEAL_RESPOND_DATE));
-        assertEquals("01 January 1900", result.get(EVIDENCE_RECEIVED_DATE_LITERAL));
-        assertEquals("12 February 1900", result.get(HEARING_CONTACT_DATE));
+        assertEquals("05 February 2018", result.get(APPEAL_RESPOND_DATE));
+        assertEquals("12 February 2018", result.get(HEARING_CONTACT_DATE));
         assertEquals("http://link.com/GLSCRR", result.get(SUBMIT_EVIDENCE_LINK_LITERAL));
+    }
+
+    @Test
+    public void setDwpResponseReceivedEventData() {
+        Event event = new Event(c1.getTime(), DWP_RESPONSE_RECEIVED);
+
+        CcdResponse response = new CcdResponse("1234", null, null, DWP_RESPONSE_RECEIVED);
+
+        response.setEvents(new ArrayList() {{
+                add(event);
+            }
+        });
+
+        Map<String, String> result = personalisation.setEventData(new HashMap<>(), response);
+
+        assertEquals("05 February 2018", result.get(APPEAL_RESPOND_DATE));
+        assertEquals("12 February 2018", result.get(HEARING_CONTACT_DATE));
+    }
+
+    @Test
+    public void setEvidenceReceivedEventData() {
+        Event event = new Event(c1.getTime(), EVIDENCE_RECEIVED);
+
+        CcdResponse response = new CcdResponse("1234", null, null, EVIDENCE_RECEIVED);
+
+        response.setEvents(new ArrayList() {{
+                add(event);
+            }
+        });
+
+        Map<String, String> result = personalisation.setEventData(new HashMap<>(), response);
+
+        assertEquals("01 January 2018", result.get(EVIDENCE_RECEIVED_DATE_LITERAL));
+    }
+
+    @Test
+    public void setPostponementEventData() {
+        Event event = new Event(c1.getTime(), POSTPONEMENT);
+
+        CcdResponse response = new CcdResponse("1234", null, null, POSTPONEMENT);
+
+        response.setEvents(new ArrayList() {{
+                add(event);
+            }
+        });
+
+        Map<String, String> result = personalisation.setEventData(new HashMap<>(), response);
+
+        assertEquals("12 February 2018", result.get(HEARING_CONTACT_DATE));
+    }
+
+    @Test
+    public void handleNullEventWhenPopulatingEventData() {
+        CcdResponse response = new CcdResponse("1234", null, null, POSTPONEMENT);
+
+        Map<String, String> result = personalisation.setEventData(new HashMap<>(), response);
+
+        assertEquals(new HashMap<>(), result);
+    }
+
+    @Test
+    public void handleEmptyEventsWhenPopulatingEventData() {
+        CcdResponse response = new CcdResponse("1234", null, null, POSTPONEMENT);
+
+        response.setEvents(new ArrayList());
+
+        Map<String, String> result = personalisation.setEventData(new HashMap<>(), response);
+
+        assertEquals(new HashMap<>(), result);
     }
 }

--- a/src/test/java/uk/gov/hmcts/sscs/personalisation/SubscriptionPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/personalisation/SubscriptionPersonalisationTest.java
@@ -77,9 +77,6 @@ public class SubscriptionPersonalisationTest {
         assertEquals("http://tyalink.com/GLSCRR", result.get(TRACK_APPEAL_LINK_LITERAL));
         assertEquals(DWP_ACRONYM, result.get(FIRST_TIER_AGENCY_ACRONYM));
         assertEquals(DWP_FUL_NAME, result.get(FIRST_TIER_AGENCY_FULL_NAME));
-        assertEquals("05 February 1900", result.get(APPEAL_RESPOND_DATE));
-        assertEquals("01 January 1900", result.get(EVIDENCE_RECEIVED_DATE_LITERAL));
-        assertEquals("12 February 1900", result.get(HEARING_CONTACT_DATE));
         assertEquals("http://link.com/GLSCRR", result.get(SUBMIT_EVIDENCE_LINK_LITERAL));
     }
 

--- a/src/test/java/uk/gov/hmcts/sscs/service/MessageAuthenticationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/service/MessageAuthenticationServiceImplTest.java
@@ -24,8 +24,8 @@ public class MessageAuthenticationServiceImplTest {
         Subscription subscription = new Subscription();
         subscription.setAppealNumber("u6ml9e");
 
-        String startEncryptedToken = service.generateToken("3").substring(0, 10);
+        String startEncryptedToken = service.generateToken("3").substring(0, 9);
 
-        assertEquals("M3wxNTE5MT", startEncryptedToken);
+        assertEquals("M3wxNTE5M", startEncryptedToken);
     }
 }


### PR DESCRIPTION
- Set Appeal respond date, Evidence received date and Hearing contact date based on the type of the latest Event