### PR TITLE
SSCS-2741 Changed the TYA urls in the notification to the following f…

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,1 +1,7 @@
 infrastructure_env = "test"
+
+evidence_submission_info_link = "https://track-appeal.nonprod.platform.hmcts.net/evidence/appeal_id"
+sscs_manage_emails_link = "https://track-appeal.nonprod.platform.hmcts.net/manage-email-notifications/mac"
+sscs_track_your_appeal_link = "https://track-appeal.nonprod.platform.hmcts.net/trackyourappeal/appeal_id"
+hearing_info_link = "https://track-appeal.nonprod.platform.hmcts.net/abouthearing/appeal_id"
+claiming_expenses_link = "https://track-appeal.nonprod.platform.hmcts.net/expenses/appeal_id"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -24,5 +24,10 @@ module "track-your-appeal-notifications" {
     S2S_URL = "${data.vault_generic_secret.s2s_url.data["value"]}"
     MANAGEMENT_SECURITY_ENABLED = "${var.management_security_enabled}"
     NOTIFICATION_API_KEY = "${data.vault_generic_secret.sscs_notify_api_key.data["value"]}"
+    EVIDENCE_SUBMISSION_INFO_LINK = "${var.evidence_submission_info_link}}"
+    SSCS_MANAGE_EMAILS_LINK = "${var.sscs_manage_emails_link}"
+    SSCS_TRACK_YOUR_APPEAL_LINK = "${var.sscs_track_your_appeal_link}"
+    HEARING_INFO_LINK = "${var.hearing_info_link}"
+    CLAIMING_EXPENSES_LINK = "${var.claiming_expenses_link}"
   }
 }

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,1 +1,7 @@
 infrastructure_env = "prod"
+
+evidence_submission_info_link = "https://track-appeal.platform.hmcts.net/evidence/appeal_id"
+sscs_manage_emails_link = "https://track-appeal.platform.hmcts.net/manage-email-notifications/mac"
+sscs_track_your_appeal_link = "https://track-appeal.platform.hmcts.net/trackyourappeal/appeal_id"
+hearing_info_link = "https://track-appeal.platform.hmcts.net/abouthearing/appeal_id"
+claiming_expenses_link = "https://track-appeal.platform.hmcts.net/expenses/appeal_id"

--- a/infrastructure/sandbox.tfvars
+++ b/infrastructure/sandbox.tfvars
@@ -1,1 +1,7 @@
 infrastructure_env = "dev"
+
+evidence_submission_info_link = "https://track-appeal-sandbox.nonprod.platform.hmcts.net/evidence/appeal_id"
+sscs_manage_emails_link = "https://track-appeal-sandbox.nonprod.platform.hmcts.net/manage-email-notifications/mac"
+sscs_track_your_appeal_link = "https://track-appeal-sandbox.nonprod.platform.hmcts.net/trackyourappeal/appeal_id"
+hearing_info_link = "https://track-appeal-sandbox.nonprod.platform.hmcts.net/abouthearing/appeal_id"
+claiming_expenses_link = "https://track-appeal-sandbox.nonprod.platform.hmcts.net/expenses/appeal_id"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -27,3 +27,28 @@ variable "ilbIp"{}
 variable "subscription" {
   type = "string"
 }
+
+variable "evidence_submission_info_link" {
+  type = "string"
+  default = "http://localhost:3000/evidence/appeal_id"
+}
+
+variable "sscs_manage_emails_link" {
+  type = "string"
+  default = "http://localhost:3000/manage-email-notifications/mac"
+}
+
+variable "sscs_track_your_appeal_link" {
+  type = "string"
+  default = "http://localhost:3000/trackyourappeal/appeal_id"
+}
+
+variable "hearing_info_link" {
+  type = "string"
+  default = "http://localhost:3000/abouthearing/appeal_id"
+}
+
+variable "claiming_expenses_link" {
+  type = "string"
+  default = "http://localhost:3000/expenses/appeal_id"
+}

--- a/src/IntegrationTests/java/uk/gov/hmcts/sscs/tya/NotificationsTyaLinksIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/sscs/tya/NotificationsTyaLinksIt.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.sscs.tya;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class NotificationsTyaLinksIt {
+
+    @Value("${manage.emails.link}")
+    private String manageEmailsLink;
+    @Value("${track.appeal.link}")
+    private String trackAppealLink;
+    @Value("${evidence.submission.info.link}")
+    private String evidenceSubmissionInfoLink;
+    @Value("${claiming.expenses.link}")
+    private String claimingExpensesLink;
+    @Value("${hearing.info.link}")
+    private String hearingInfoLink;
+
+    @Test
+    public void shouldVerifyTyaLinksAreInValidFormat() {
+        assertThat(manageEmailsLink.endsWith("/manage-email-notifications/mac"), equalTo(true));
+        assertThat(trackAppealLink.endsWith("/trackyourappeal/appeal_id"), equalTo(true));
+        assertThat(evidenceSubmissionInfoLink.endsWith("/evidence/appeal_id"), equalTo(true));
+        assertThat(claimingExpensesLink.endsWith("/expenses/appeal_id"), equalTo(true));
+        assertThat(hearingInfoLink.endsWith("/abouthearing/appeal_id"), equalTo(true));
+    }
+}

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -6,11 +6,11 @@ management.enabled=${MANAGEMENT_SECURITY_ENABLED:true}
 
 hmcts.phone.number=0300 123 1142
 
-evidence.submission.info.link=${EVIDENCE_SUBMISSION_INFO_LINK:http://localhost:3000/progress/appeal_id/evidence}
+evidence.submission.info.link=${EVIDENCE_SUBMISSION_INFO_LINK:http://localhost:3000/evidence/appeal_id}
 manage.emails.link=${SSCS_MANAGE_EMAILS_LINK:http://localhost:3000/manage-email-notifications/mac}
-track.appeal.link=${SSCS_TRACK_YOUR_APPEAL_LINK:http://localhost:3000/progress/appeal_id/trackyourappeal}
-hearing.info.link=${HEARING_INFO_LINK:http://localhost:3000/progress/appeal_id/abouthearing}
-claiming.expenses.link=${CLAIMING_EXPENSES_LINK:http://localhost:3000/progress/appeal_id/expenses}
+track.appeal.link=${SSCS_TRACK_YOUR_APPEAL_LINK:http://localhost:3000/trackyourappeal/appeal_id}
+hearing.info.link=${HEARING_INFO_LINK:http://localhost:3000/abouthearing/appeal_id}
+claiming.expenses.link=${CLAIMING_EXPENSES_LINK:http://localhost:3000/expenses/appeal_id}
 
 gov.uk.notification.api.key=${NOTIFICATION_API_KEY:emailnotificationkey}
 subscription.hmac.secret.text=${EMAIL_MAC_SECRET_TEXT:our-big-secret}


### PR DESCRIPTION
…ormats

https://track-appeal.nonprod.platform.hmcts.net/evidence/<appeal_number>

https://track-appeal.nonprod.platform.hmcts.net/manage-email-notifications/<mac_id>

https://track-appeal.nonprod.platform.hmcts.net/trackyourappeal/<appeal_number>

https://track-appeal.nonprod.platform.hmcts.net/abouthearing/<appeal_number>

https://track-appeal.nonprod.platform.hmcts.net/expenses/<appeal_number>
: