### PR TITLE
SSCS-2930 Notification benefit type

### DIFF
--- a/src/IntegrationTests/resources/json/ccdCallbackResponse.json
+++ b/src/IntegrationTests/resources/json/ccdCallbackResponse.json
@@ -34,8 +34,7 @@
           }
         },
         "benefitType": {
-          "code": "JSA",
-          "description": "Job Seekers"
+          "code": "JSA"
         },
         "hearingOptions": {
           "arrangements": [
@@ -140,8 +139,7 @@
           }
         },
         "benefitType": {
-          "code": "JSA",
-          "description": "Job Seekers"
+          "code": "JSA"
         },
         "hearingOptions": {
           "arrangements": [

--- a/src/main/java/uk/gov/hmcts/sscs/config/AppConstants.java
+++ b/src/main/java/uk/gov/hmcts/sscs/config/AppConstants.java
@@ -7,8 +7,6 @@ public final class AppConstants {
     public static final String APPEAL_ID_LITERAL = "appeal_id";
     public static final String APPEAL_RESPOND_DATE = "appeal_respond_date";
     public static final String APPELLANT_NAME = "name";
-    public static final String BENEFIT_NAME_ACRONYM = "ESA benefit";
-    public static final String BENEFIT_FULL_NAME = "Employment Support Allowance";
     public static final String BENEFIT_NAME_ACRONYM_LITERAL = "benefit_name_acronym";
     public static final String BENEFIT_FULL_NAME_LITERAL = "benefit_full_name";
     public static final String CLAIMING_EXPENSES_LINK_LITERAL = "claiming_expenses_link";

--- a/src/main/java/uk/gov/hmcts/sscs/deserialize/CcdResponseDeserializer.java
+++ b/src/main/java/uk/gov/hmcts/sscs/deserialize/CcdResponseDeserializer.java
@@ -14,10 +14,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.sscs.domain.CcdResponse;
-import uk.gov.hmcts.sscs.domain.CcdResponseWrapper;
-import uk.gov.hmcts.sscs.domain.Hearing;
-import uk.gov.hmcts.sscs.domain.Subscription;
+import uk.gov.hmcts.sscs.domain.*;
 import uk.gov.hmcts.sscs.domain.notify.Event;
 import uk.gov.hmcts.sscs.domain.notify.EventType;
 
@@ -85,7 +82,8 @@ public class CcdResponseDeserializer extends StdDeserializer<CcdResponseWrapper>
         JsonNode benefitTypeNode = getNode(appealNode, "benefitType");
 
         if (benefitTypeNode != null) {
-            ccdResponse.setBenefitType(getField(benefitTypeNode, "code"));
+            String benefitCode = getField(benefitTypeNode, "code");
+            ccdResponse.setBenefitType(Benefit.getBenefitByCode(benefitCode));
         }
 
         return ccdResponse;

--- a/src/main/java/uk/gov/hmcts/sscs/domain/Benefit.java
+++ b/src/main/java/uk/gov/hmcts/sscs/domain/Benefit.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.sscs.domain;
+
+public enum Benefit {
+
+    ESA("Employment Support Allowance"),
+    JSA("Job Seekers Allowance"),
+    PIP("Personal Independence Payment");
+
+    private String description;
+
+    Benefit(String description) {
+        this.description = description;
+    }
+
+    public static Benefit getBenefitByCode(String code) {
+        Benefit b = null;
+        for (Benefit type : Benefit.values()) {
+            if (type.name().equals(code)) {
+                b = type;
+            }
+        }
+        return b;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/sscs/domain/CcdResponse.java
+++ b/src/main/java/uk/gov/hmcts/sscs/domain/CcdResponse.java
@@ -6,7 +6,7 @@ import uk.gov.hmcts.sscs.domain.notify.EventType;
 
 public class CcdResponse {
 
-    private String benefitType;
+    private Benefit benefitType;
     private String caseReference;
     private Subscription appellantSubscription;
     private Subscription supporterSubscription;
@@ -18,7 +18,7 @@ public class CcdResponse {
         //
     }
 
-    public CcdResponse(String benefitType,
+    public CcdResponse(Benefit benefitType,
                        String caseReference,
                        Subscription appellantSubscription,
                        Subscription supporterSubscription,
@@ -32,11 +32,11 @@ public class CcdResponse {
         this.hearings = hearings;
     }
 
-    public String getBenefitType() {
+    public Benefit getBenefitType() {
         return benefitType;
     }
 
-    public void setBenefitType(String benefitType) {
+    public void setBenefitType(Benefit benefitType) {
         this.benefitType = benefitType;
     }
 
@@ -91,7 +91,8 @@ public class CcdResponse {
     @Override
     public String toString() {
         return "CcdResponse{"
-                + " caseReference='" + caseReference + '\''
+                + " benefitType='" + benefitType + '\''
+                + ", caseReference='" + caseReference + '\''
                 + ", appellantSubscription=" + appellantSubscription
                 + ", supporterSubscription=" + supporterSubscription
                 + ", notificationType=" + notificationType

--- a/src/main/java/uk/gov/hmcts/sscs/personalisation/Personalisation.java
+++ b/src/main/java/uk/gov/hmcts/sscs/personalisation/Personalisation.java
@@ -34,8 +34,8 @@ public class Personalisation {
     public Map<String, String> create(CcdResponseWrapper responseWrapper) {
         CcdResponse ccdResponse = responseWrapper.getNewCcdResponse();
         Map<String, String> personalisation = new HashMap<>();
-        personalisation.put(BENEFIT_NAME_ACRONYM_LITERAL, BENEFIT_NAME_ACRONYM);
-        personalisation.put(BENEFIT_FULL_NAME_LITERAL, BENEFIT_FULL_NAME);
+        personalisation.put(BENEFIT_NAME_ACRONYM_LITERAL, ccdResponse.getBenefitType().name() + " benefit");
+        personalisation.put(BENEFIT_FULL_NAME_LITERAL, ccdResponse.getBenefitType().getDescription());
         personalisation.put(APPEAL_REF, ccdResponse.getCaseReference());
         personalisation.put(APPELLANT_NAME, String.format("%s %s", ccdResponse.getAppellantSubscription().getFirstName(), ccdResponse.getAppellantSubscription().getSurname()));
         personalisation.put(PHONE_NUMBER, config.getHmctsPhoneNumber());
@@ -44,7 +44,7 @@ public class Personalisation {
             personalisation.put(APPEAL_ID, ccdResponse.getAppellantSubscription().getAppealNumber());
             personalisation.put(MANAGE_EMAILS_LINK_LITERAL, config.getManageEmailsLink().replace(MAC_LITERAL,
                     getMacToken(ccdResponse.getAppellantSubscription().getAppealNumber(),
-                            ccdResponse.getBenefitType())));
+                            ccdResponse.getBenefitType().name())));
             personalisation.put(TRACK_APPEAL_LINK_LITERAL, config.getTrackAppealLink() != null ? config.getTrackAppealLink().replace(APPEAL_ID_LITERAL, ccdResponse.getAppellantSubscription().getAppealNumber()) : null);
             personalisation.put(SUBMIT_EVIDENCE_LINK_LITERAL, config.getEvidenceSubmissionInfoLink().replace(APPEAL_ID, ccdResponse.getAppellantSubscription().getAppealNumber()));
             personalisation.put(CLAIMING_EXPENSES_LINK_LITERAL, config.getClaimingExpensesLink().replace(APPEAL_ID, ccdResponse.getAppellantSubscription().getAppealNumber()));

--- a/src/test/java/uk/gov/hmcts/sscs/deserialize/CcdResponseDeserializerTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/deserialize/CcdResponseDeserializerTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.sscs.deserialize;
 
 import static org.junit.Assert.*;
 import static uk.gov.hmcts.sscs.config.AppConstants.ZONE_ID;
+import static uk.gov.hmcts.sscs.domain.Benefit.PIP;
 import static uk.gov.hmcts.sscs.domain.notify.EventType.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,11 +33,11 @@ public class CcdResponseDeserializerTest {
     @Test
     public void deserializeBenefitJson() throws IOException {
 
-        String appealJson = "{\"benefitType\":{\"code\":\"002\"}}";
+        String appealJson = "{\"benefitType\":{\"code\":\"PIP\"}}";
 
         CcdResponse ccdResponse = ccdResponseDeserializer.deserializeBenefitDetailsJson(mapper.readTree(appealJson), new CcdResponse());
 
-        assertEquals("002", ccdResponse.getBenefitType());
+        assertEquals(PIP, ccdResponse.getBenefitType());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/sscs/factory/NotificationFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/factory/NotificationFactoryTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static uk.gov.hmcts.sscs.domain.Benefit.PIP;
 import static uk.gov.hmcts.sscs.domain.notify.EventType.*;
 
 import java.time.ZonedDateTime;
@@ -48,7 +49,7 @@ public class NotificationFactoryTest {
         personalisation = new Personalisation(config, macService);
         subscriptionPersonalisation = new SubscriptionPersonalisation(config, macService);
         factory = new NotificationFactory(personalisationFactory);
-        wrapper = new CcdResponseWrapper(new CcdResponse("002","SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
+        wrapper = new CcdResponseWrapper(new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
                 "ABC","test@testing.com", "07985858594", true, false), null, APPEAL_RECEIVED, null), null);
         when(config.getHmctsPhoneNumber()).thenReturn("01234543225");
         when(config.getManageEmailsLink()).thenReturn(new Link("http://manageemails.com/mac"));
@@ -57,7 +58,7 @@ public class NotificationFactoryTest {
         when(config.getManageEmailsLink()).thenReturn(new Link("http://link.com/manage-email-notifications/mac"));
         when(config.getClaimingExpensesLink()).thenReturn(new Link("http://link.com/progress/appeal_id/expenses"));
         when(config.getHearingInfoLink()).thenReturn(new Link("http://link.com/progress/appeal_id/abouthearing"));
-        when(macService.generateToken("ABC", "002")).thenReturn("ZYX");
+        when(macService.generateToken("ABC", PIP.name())).thenReturn("ZYX");
     }
 
     @Test
@@ -76,10 +77,10 @@ public class NotificationFactoryTest {
         when(personalisationFactory.apply(SUBSCRIPTION_UPDATED)).thenReturn(subscriptionPersonalisation);
         when(config.getTemplate(SUBSCRIPTION_UPDATED.getId(), SUBSCRIPTION_CREATED.getId())).thenReturn(new Template(null, "123"));
 
-        wrapper = new CcdResponseWrapper(new CcdResponse("002","SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
+        wrapper = new CcdResponseWrapper(new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
                 "ABC", "test@testing.com", "07985858594", true, false), null, SUBSCRIPTION_UPDATED, null),
-                new CcdResponse("002", "SC/1234/5", new Subscription("Ronnie", "Scott", "Mr", "ABC",
-                "test@testing.com", "07985858594", false, false), null, SUBSCRIPTION_UPDATED, null));
+                new CcdResponse(PIP, "SC/1234/5", new Subscription("Ronnie", "Scott", "Mr", "ABC",
+                        "test@testing.com", "07985858594", false, false), null, SUBSCRIPTION_UPDATED, null));
 
         Notification result = factory.create(wrapper);
 
@@ -91,10 +92,10 @@ public class NotificationFactoryTest {
         when(personalisationFactory.apply(SUBSCRIPTION_UPDATED)).thenReturn(subscriptionPersonalisation);
         when(config.getTemplate(SUBSCRIPTION_UPDATED.getId(), SUBSCRIPTION_UPDATED.getId())).thenReturn(new Template(null, "123"));
 
-        wrapper = new CcdResponseWrapper(new CcdResponse("002", "SC/1234/5", new Subscription("Ronnie", "Scott",
+        wrapper = new CcdResponseWrapper(new CcdResponse(PIP, "SC/1234/5", new Subscription("Ronnie", "Scott",
                 "Mr", "ABC",
                 "test@testing.com", "07985858594", true, false), null, SUBSCRIPTION_UPDATED, null),
-                new CcdResponse("002","SC/1234/5", new Subscription("Ronnie", "Scott", "Mr", "ABC",
+                new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr", "ABC",
                         "test@testing.com", "07985858594", true, false), null, SUBSCRIPTION_UPDATED, null));
 
         Notification result = factory.create(wrapper);
@@ -107,13 +108,13 @@ public class NotificationFactoryTest {
         when(personalisationFactory.apply(SUBSCRIPTION_UPDATED)).thenReturn(subscriptionPersonalisation);
         when(config.getTemplate(APPEAL_RECEIVED.getId(), SUBSCRIPTION_CREATED.getId())).thenReturn(new Template("123", null));
 
-        CcdResponse newResponse = new CcdResponse("002", "SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
+        CcdResponse newResponse = new CcdResponse(PIP, "SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
                 "ABC",
                 "test@testing.com", "07985858594", true, true), null, SUBSCRIPTION_UPDATED, null);
 
-        CcdResponse oldResponse = new CcdResponse("002","SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
+        CcdResponse oldResponse = new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
                 "ABC",
-                        "test@testing.com", "07985858594", false, false), null, SUBSCRIPTION_UPDATED, null);
+                "test@testing.com", "07985858594", false, false), null, SUBSCRIPTION_UPDATED, null);
 
         Event event = new Event(ZonedDateTime.now(), APPEAL_RECEIVED);
         newResponse.setEvents(new ArrayList() {{
@@ -133,11 +134,11 @@ public class NotificationFactoryTest {
         when(personalisationFactory.apply(SUBSCRIPTION_UPDATED)).thenReturn(subscriptionPersonalisation);
         when(config.getTemplate(SUBSCRIPTION_UPDATED.getId(), SUBSCRIPTION_CREATED.getId())).thenReturn(new Template("123", null));
 
-        CcdResponse newResponse = new CcdResponse("002","SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
+        CcdResponse newResponse = new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
                 "ABC",
                 "test@testing.com", "07985858594", true, true), null, SUBSCRIPTION_UPDATED, null);
 
-        CcdResponse oldResponse = new CcdResponse("002","SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
+        CcdResponse oldResponse = new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
                 "ABC",
                 "test@testing.com", "07985858594", false, true), null, SUBSCRIPTION_UPDATED, null);
 

--- a/src/test/java/uk/gov/hmcts/sscs/personalisation/PersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/personalisation/PersonalisationTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static uk.gov.hmcts.sscs.config.AppConstants.*;
+import static uk.gov.hmcts.sscs.domain.Benefit.PIP;
 import static uk.gov.hmcts.sscs.domain.notify.EventType.*;
 
 import java.time.LocalDate;
@@ -47,7 +48,7 @@ public class PersonalisationTest {
         when(config.getManageEmailsLink()).thenReturn(new Link("http://link.com/manage-email-notifications/mac"));
         when(config.getClaimingExpensesLink()).thenReturn(new Link("http://link.com/progress/appeal_id/expenses"));
         when(config.getHearingInfoLink()).thenReturn(new Link("http://link.com/progress/appeal_id/abouthearing"));
-        when(macService.generateToken("GLSCRR", "002")).thenReturn("ZYX");
+        when(macService.generateToken("GLSCRR", PIP.name())).thenReturn("ZYX");
 
         dateTime = ZonedDateTime.of(LocalDate.of(2018, 1, 1), LocalTime.of(0, 0), ZoneId.of(ZONE_ID));
     }
@@ -59,7 +60,7 @@ public class PersonalisationTest {
         Subscription appellantSubscription = new Subscription("Harry", "Kane", "Mr", "GLSCRR", "test@email.com",
                 "07983495065", true, false);
 
-        CcdResponse response = new CcdResponse("002", "1234", appellantSubscription, null, APPEAL_RECEIVED, null);
+        CcdResponse response = new CcdResponse(PIP, "1234", appellantSubscription, null, APPEAL_RECEIVED, null);
         response.setEvents(new ArrayList() {{
                 add(event);
             }
@@ -67,8 +68,8 @@ public class PersonalisationTest {
 
         Map<String, String> result = personalisation.create(new CcdResponseWrapper(response, null));
 
-        assertEquals(BENEFIT_NAME_ACRONYM, result.get(BENEFIT_NAME_ACRONYM_LITERAL));
-        assertEquals(BENEFIT_FULL_NAME, result.get(BENEFIT_FULL_NAME_LITERAL));
+        assertEquals("PIP benefit", result.get(BENEFIT_NAME_ACRONYM_LITERAL));
+        assertEquals("Personal Independence Payment", result.get(BENEFIT_FULL_NAME_LITERAL));
         assertEquals("1234", result.get(APPEAL_REF));
         assertEquals("GLSCRR", result.get(APPEAL_ID));
         assertEquals("Harry Kane", result.get(APPELLANT_NAME));
@@ -88,7 +89,7 @@ public class PersonalisationTest {
     public void setAppealReceivedEventData() {
         Event event = new Event(dateTime, APPEAL_RECEIVED);
 
-        CcdResponse response = new CcdResponse("002","1234", null, null, APPEAL_RECEIVED, null);
+        CcdResponse response = new CcdResponse(PIP,"1234", null, null, APPEAL_RECEIVED, null);
 
         response.setEvents(new ArrayList() {{
                 add(event);
@@ -105,7 +106,7 @@ public class PersonalisationTest {
     public void setEvidenceReceivedEventData() {
         Event event = new Event(dateTime, EVIDENCE_RECEIVED);
 
-        CcdResponse response = new CcdResponse("002","1234", null, null, EVIDENCE_RECEIVED, null);
+        CcdResponse response = new CcdResponse(PIP,"1234", null, null, EVIDENCE_RECEIVED, null);
 
         response.setEvents(new ArrayList() {{
                 add(event);
@@ -125,7 +126,7 @@ public class PersonalisationTest {
         Subscription appellantSubscription = new Subscription("Harry", "Kane", "Mr", "GLSCRR", "test@email.com",
                 "07983495065", true, false);
 
-        CcdResponse response = new CcdResponse("002", "1234", appellantSubscription, null, EVIDENCE_RECEIVED, null);
+        CcdResponse response = new CcdResponse(PIP, "1234", appellantSubscription, null, EVIDENCE_RECEIVED, null);
         response.setEvents(new ArrayList() {{
                 add(event1);
                 add(event2);
@@ -141,7 +142,7 @@ public class PersonalisationTest {
     public void setPostponementEventData() {
         Event event = new Event(dateTime, POSTPONEMENT);
 
-        CcdResponse response = new CcdResponse("002","1234", null, null, POSTPONEMENT, null);
+        CcdResponse response = new CcdResponse(PIP,"1234", null, null, POSTPONEMENT, null);
 
         response.setEvents(new ArrayList() {{
                 add(event);
@@ -155,7 +156,7 @@ public class PersonalisationTest {
 
     @Test
     public void handleNullEventWhenPopulatingEventData() {
-        CcdResponse response = new CcdResponse("002","1234", null, null, POSTPONEMENT, null);
+        CcdResponse response = new CcdResponse(PIP,"1234", null, null, POSTPONEMENT, null);
 
         Map<String, String> result = personalisation.setEventData(new HashMap<>(), response);
 
@@ -164,7 +165,7 @@ public class PersonalisationTest {
 
     @Test
     public void handleEmptyEventsWhenPopulatingEventData() {
-        CcdResponse response = new CcdResponse("002","1234", null, null, POSTPONEMENT, null);
+        CcdResponse response = new CcdResponse(PIP,"1234", null, null, POSTPONEMENT, null);
 
         response.setEvents(new ArrayList());
 

--- a/src/test/java/uk/gov/hmcts/sscs/personalisation/SubscriptionPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/personalisation/SubscriptionPersonalisationTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static uk.gov.hmcts.sscs.config.AppConstants.*;
+import static uk.gov.hmcts.sscs.domain.Benefit.PIP;
 import static uk.gov.hmcts.sscs.domain.notify.EventType.*;
 
 import java.time.ZonedDateTime;
@@ -51,7 +52,7 @@ public class SubscriptionPersonalisationTest {
         when(config.getManageEmailsLink()).thenReturn(new Link("http://link.com/manage-email-notifications/mac"));
         when(config.getClaimingExpensesLink()).thenReturn(new Link("http://link.com/progress/appeal_id/expenses"));
         when(config.getHearingInfoLink()).thenReturn(new Link("http://link.com/progress/appeal_id/abouthearing"));
-        when(macService.generateToken("GLSCRR", "002")).thenReturn("ZYX");
+        when(macService.generateToken("GLSCRR", PIP.name())).thenReturn("ZYX");
 
         newAppellantSubscription = new Subscription("Harry", "Kane", "Mr", "GLSCRR", "test@email.com",
                 "07983495065", true, true);
@@ -59,18 +60,18 @@ public class SubscriptionPersonalisationTest {
         oldAppellantSubscription = new Subscription("Harry", "Kane", "Mr", "GLSCRR", "test@email.com",
                 "07983495065", false, false);
 
-        newCcdResponse = new CcdResponse("002","1234", newAppellantSubscription, null, DWP_RESPONSE_RECEIVED, null);
-        oldCcdResponse = new CcdResponse("002","5432", oldAppellantSubscription, null, DWP_RESPONSE_RECEIVED, null);
+        newCcdResponse = new CcdResponse(PIP,"1234", newAppellantSubscription, null, DWP_RESPONSE_RECEIVED, null);
+        oldCcdResponse = new CcdResponse(PIP,"5432", oldAppellantSubscription, null, DWP_RESPONSE_RECEIVED, null);
     }
 
     @Test
     public void customisePersonalisation() {
         Map<String, String> result = personalisation.create(new CcdResponseWrapper(
-                new CcdResponse("002","1234", newAppellantSubscription, null, DWP_RESPONSE_RECEIVED, null),
-                new CcdResponse("002","5432", oldAppellantSubscription, null, DWP_RESPONSE_RECEIVED, null)));
+                new CcdResponse(PIP,"1234", newAppellantSubscription, null, DWP_RESPONSE_RECEIVED, null),
+                new CcdResponse(PIP,"5432", oldAppellantSubscription, null, DWP_RESPONSE_RECEIVED, null)));
 
-        assertEquals(BENEFIT_NAME_ACRONYM, result.get(BENEFIT_NAME_ACRONYM_LITERAL));
-        assertEquals(BENEFIT_FULL_NAME, result.get(BENEFIT_FULL_NAME_LITERAL));
+        assertEquals("PIP benefit", result.get(BENEFIT_NAME_ACRONYM_LITERAL));
+        assertEquals("Personal Independence Payment", result.get(BENEFIT_FULL_NAME_LITERAL));
         assertEquals("1234", result.get(APPEAL_REF));
         assertEquals("GLSCRR", result.get(APPEAL_ID));
         assertEquals("Harry Kane", result.get(APPELLANT_NAME));
@@ -110,7 +111,7 @@ public class SubscriptionPersonalisationTest {
     @Test
     public void emptyOldAppellantSubscriptionReturnsFalseForSubscriptionCreatedNotificationType() {
         Boolean result = personalisation.shouldSendSmsSubscriptionConfirmation(
-                newCcdResponse, new CcdResponse("002","5432", null, null, DWP_RESPONSE_RECEIVED, null));
+                newCcdResponse, new CcdResponse(PIP,"5432", null, null, DWP_RESPONSE_RECEIVED, null));
 
         assertFalse(result);
     }
@@ -118,7 +119,7 @@ public class SubscriptionPersonalisationTest {
     @Test
     public void emptyNewAppellantSubscriptionReturnsFalseForSubscriptionCreatedNotificationType() {
         Boolean result = personalisation.shouldSendSmsSubscriptionConfirmation(
-                new CcdResponse("002","1234", null, null, DWP_RESPONSE_RECEIVED, null), oldCcdResponse);
+                new CcdResponse(PIP,"1234", null, null, DWP_RESPONSE_RECEIVED, null), oldCcdResponse);
 
         assertFalse(result);
     }


### PR DESCRIPTION
- Extract the benefit code and description from the CCD response
- Use this to create the benefit type used in the subject line of most notifications