### PR TITLE
SSCS-2701 Send change subscription details email

### DIFF
--- a/src/IntegrationTests/resources/json/ccdCallbackResponse.json
+++ b/src/IntegrationTests/resources/json/ccdCallbackResponse.json
@@ -84,7 +84,7 @@
       "region": "Liverpool",
       "subscriptions": {
         "appellantSubscription": {
-          "email": "tester@hmcts.net",
+          "email": "updatedemail@hmcts.net",
           "mobile": "07985233301",
           "reason": null,
           "subscribeEmail": "Yes",

--- a/src/main/java/uk/gov/hmcts/sscs/domain/notify/EventType.java
+++ b/src/main/java/uk/gov/hmcts/sscs/domain/notify/EventType.java
@@ -12,7 +12,8 @@ public enum EventType {
     HEARING_BOOKED("hearingBooked"),
     POSTPONEMENT("hearingPostponed"),
     SUBSCRIPTION_CREATED("subscriptionCreated"),
-    SUBSCRIPTION_UPDATED("subscriptionUpdated");
+    SUBSCRIPTION_UPDATED("subscriptionUpdated"),
+    DO_NOT_SEND("");
 
     private String id;
 

--- a/src/main/java/uk/gov/hmcts/sscs/personalisation/SubscriptionPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/sscs/personalisation/SubscriptionPersonalisation.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import uk.gov.hmcts.sscs.config.NotificationConfig;
 import uk.gov.hmcts.sscs.domain.CcdResponse;
 import uk.gov.hmcts.sscs.domain.CcdResponseWrapper;
+import uk.gov.hmcts.sscs.domain.notify.EventType;
 import uk.gov.hmcts.sscs.service.MessageAuthenticationServiceImpl;
 
 public class SubscriptionPersonalisation extends Personalisation {
@@ -16,6 +17,7 @@ public class SubscriptionPersonalisation extends Personalisation {
     public Map<String, String> create(CcdResponseWrapper responseWrapper) {
         setSendSmsSubscriptionConfirmation(shouldSendSmsSubscriptionConfirmation(responseWrapper.getNewCcdResponse(), responseWrapper.getOldCcdResponse()));
         setMostRecentEventTypeNotification(responseWrapper.getNewCcdResponse(), responseWrapper.getOldCcdResponse());
+        doNotSendEmailUpdatedNotificationWhenEmailNotChanged(responseWrapper.getNewCcdResponse(), responseWrapper.getOldCcdResponse());
 
         return super.create(responseWrapper);
     }
@@ -36,6 +38,17 @@ public class SubscriptionPersonalisation extends Personalisation {
                 && !newCcdResponse.getEvents().isEmpty()) {
 
             newCcdResponse.setNotificationType(newCcdResponse.getEvents().get(0).getEventType());
+        }
+        return newCcdResponse;
+    }
+
+    public CcdResponse doNotSendEmailUpdatedNotificationWhenEmailNotChanged(CcdResponse newCcdResponse, CcdResponse oldCcdResponse) {
+        if (oldCcdResponse.getAppellantSubscription() != null
+                && oldCcdResponse.getAppellantSubscription().isSubscribeEmail()
+                && newCcdResponse.getAppellantSubscription() != null
+                && newCcdResponse.getAppellantSubscription().isSubscribeEmail()
+                && oldCcdResponse.getAppellantSubscription().getEmail().equals(newCcdResponse.getAppellantSubscription().getEmail())) {
+            newCcdResponse.setNotificationType(EventType.DO_NOT_SEND);
         }
         return newCcdResponse;
     }

--- a/src/main/java/uk/gov/hmcts/sscs/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/sscs/service/NotificationService.java
@@ -32,12 +32,12 @@ public class NotificationService {
         Notification notification = factory.create(responseWrapper);
 
         try {
-            if (notification.isEmail() && notification.getEmailTemplate() != null) {
+            if (responseWrapper.getNewCcdResponse().getAppellantSubscription().isSubscribeEmail() && notification.isEmail() && notification.getEmailTemplate() != null) {
                 LOG.info("Sending email for case reference "  + responseWrapper.getNewCcdResponse().getCaseReference());
                 client.sendEmail(notification.getEmailTemplate(), notification.getEmail(), notification.getPlaceholders(), notification.getReference());
                 LOG.info("Email sent for case reference "  + responseWrapper.getNewCcdResponse().getCaseReference());
             }
-            if (notification.isSms() && notification.getSmsTemplate() != null) {
+            if (responseWrapper.getNewCcdResponse().getAppellantSubscription().isSubscribeSms() && notification.isSms() && notification.getSmsTemplate() != null) {
                 LOG.info("Sending SMS for case reference "  + responseWrapper.getNewCcdResponse().getCaseReference());
                 client.sendSms(notification.getSmsTemplate(), notification.getMobile(), notification.getPlaceholders(), notification.getReference());
                 LOG.info("SMS sent for case reference "  + responseWrapper.getNewCcdResponse().getCaseReference());

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -36,4 +36,6 @@ notification.appealWithdrawn.emailId=${APPEAL_WITHDRAWN_EMAIL_TEMPLATE_ID:8620e0
 
 notification.subscriptionCreated.smsId=${SUBSCRIPTION_CREATED_SMS_TEMPLATE_ID:18444f5f-8834-49e9-a6ae-bfe7f50db2b8}
 
+notification.subscriptionUpdated.emailId=${SUBSCRIPTION_UPDATED_EMAIL_TEMPLATE_ID:820901f0-15a9-4796-bdec-0cef42922531}
+
 notification.hearingBooked.emailId=${HEARING_BOOKED_EMAIL_TEMPLATE_ID:fee16753-0bdb-43f1-9abb-b14b826e3b26}

--- a/src/test/java/uk/gov/hmcts/sscs/factory/NotificationFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/factory/NotificationFactoryTest.java
@@ -130,13 +130,40 @@ public class NotificationFactoryTest {
     }
 
     @Test
-    public void buildSubscriptionUpdatedNotificationFromCcdResponseWhenEmailAlreadySubscribed() {
+    public void buildNoNotificationFromCcdResponseWhenSubscriptionUpdateReceivedWithNoChangeInEmailAddress() {
+        when(personalisationFactory.apply(SUBSCRIPTION_UPDATED)).thenReturn(subscriptionPersonalisation);
+        when(config.getTemplate(DO_NOT_SEND.getId(), SUBSCRIPTION_CREATED.getId())).thenReturn(new Template(null, null));
+
+        CcdResponse newResponse = new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
+                "ABC",
+                "test@testing.com", "07985858594", true, true), null, SUBSCRIPTION_UPDATED, null);
+
+        CcdResponse oldResponse = new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
+                "ABC",
+                "test@testing.com", "07985858594", false, true), null, SUBSCRIPTION_UPDATED, null);
+
+        Event event = new Event(ZonedDateTime.now(), APPEAL_RECEIVED);
+
+        newResponse.setEvents(new ArrayList() {{
+                add(event);
+            }
+        });
+
+        wrapper = new CcdResponseWrapper(newResponse, oldResponse);
+
+        Notification result = factory.create(wrapper);
+
+        assertNull(result.getEmailTemplate());
+    }
+
+    @Test
+    public void buildSubscriptionUpdatedNotificationFromCcdResponseWhenEmailIsChanged() {
         when(personalisationFactory.apply(SUBSCRIPTION_UPDATED)).thenReturn(subscriptionPersonalisation);
         when(config.getTemplate(SUBSCRIPTION_UPDATED.getId(), SUBSCRIPTION_CREATED.getId())).thenReturn(new Template("123", null));
 
         CcdResponse newResponse = new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
                 "ABC",
-                "test@testing.com", "07985858594", true, true), null, SUBSCRIPTION_UPDATED, null);
+                "changed@testing.com", "07985858594", true, true), null, SUBSCRIPTION_UPDATED, null);
 
         CcdResponse oldResponse = new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
                 "ABC",

--- a/src/test/java/uk/gov/hmcts/sscs/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/service/NotificationServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import uk.gov.hmcts.sscs.domain.CcdResponse;
 import uk.gov.hmcts.sscs.domain.CcdResponseWrapper;
+import uk.gov.hmcts.sscs.domain.Subscription;
 import uk.gov.hmcts.sscs.domain.notify.Destination;
 import uk.gov.hmcts.sscs.domain.notify.Notification;
 import uk.gov.hmcts.sscs.domain.notify.Reference;
@@ -38,6 +39,7 @@ public class NotificationServiceTest {
         initMocks(this);
         notificationService = new NotificationService(client, factory);
         CcdResponse response = new CcdResponse();
+        response.setAppellantSubscription(new Subscription("", "", "", "", "", "", true, true));
         response.setCaseReference("ABC123");
         wrapper = new CcdResponseWrapper(response, response);
     }


### PR DESCRIPTION
- When an email address subscription is changed then send a confirmation email to the new email address
- Do not send emails or texts when relevant subscription flags are set to false