### PR TITLE
Fix exception thrown when notification type not known

### DIFF
--- a/src/main/java/uk/gov/hmcts/sscs/personalisation/SubscriptionPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/sscs/personalisation/SubscriptionPersonalisation.java
@@ -35,7 +35,8 @@ public class SubscriptionPersonalisation extends Personalisation {
                 && newCcdResponse.getAppellantSubscription() != null
                 && newCcdResponse.getAppellantSubscription().isSubscribeEmail()
                 && newCcdResponse.getEvents() != null
-                && !newCcdResponse.getEvents().isEmpty()) {
+                && !newCcdResponse.getEvents().isEmpty()
+                && newCcdResponse.getEvents().get(0).getEventType() != null) {
 
             newCcdResponse.setNotificationType(newCcdResponse.getEvents().get(0).getEventType());
         }

--- a/src/test/java/uk/gov/hmcts/sscs/personalisation/SubscriptionPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/personalisation/SubscriptionPersonalisationTest.java
@@ -187,6 +187,19 @@ public class SubscriptionPersonalisationTest {
     }
 
     @Test
+    public void doNotUpdateMostRecentEventTypeNotificationWhenEventTypeIsNotKnown() {
+        Event event = new Event(ZonedDateTime.now(), null);
+        newCcdResponse.setEvents(new ArrayList() {{
+                add(event);
+            }
+        });
+
+        CcdResponse result = personalisation.setMostRecentEventTypeNotification(newCcdResponse, oldCcdResponse);
+
+        assertEquals(SUBSCRIPTION_UPDATED, result.getNotificationType());
+    }
+
+    @Test
     public void emptyOldAppellantSubscriptionDoesNotUpdateNotificationType() {
         oldCcdResponse.setAppellantSubscription(null);
 


### PR DESCRIPTION
This PR fixes this edge case:

1. Latest event on a case is Appeal Dormant
2. It has no subscriptions
3. User adds a new subscription 
4. Notification service tries to find the latest event. In this case it is appeal dormant but notification service doesn't know about this case (as no notifications for appeal dormant)
5. Blows up with a null pointer