### PR TITLE
SSCS-2704 Extract caseId

### DIFF
--- a/src/IntegrationTests/resources/json/ccdCallbackResponse.json
+++ b/src/IntegrationTests/resources/json/ccdCallbackResponse.json
@@ -120,7 +120,8 @@
       }
     },
     "case_type_id": "Benefit",
-    "state": "appealCreated"
+    "state": "appealCreated",
+    "id": "12345656789"
   },
   "case_details_before": {
     "after_submit_callback_response": null,
@@ -225,7 +226,8 @@
       }
     },
     "case_type_id": "Benefit",
-    "state": "appealCreated"
+    "state": "appealCreated",
+    "id": "12345656789"
   },
   "event_id": "appealReceived"
 }

--- a/src/main/java/uk/gov/hmcts/sscs/deserialize/CcdResponseDeserializer.java
+++ b/src/main/java/uk/gov/hmcts/sscs/deserialize/CcdResponseDeserializer.java
@@ -45,19 +45,24 @@ public class CcdResponseDeserializer extends StdDeserializer<CcdResponseWrapper>
         JsonNode caseNode = getNode(caseDetailsNode, "case_data");
 
         if (caseNode != null) {
-            newCcdResponse = deserializeCaseNode(caseNode);
-            newCcdResponse.setNotificationType(EventType.getNotificationById(getField(node, "event_id")));
+            newCcdResponse = createCcdResponseFromNode(caseNode, node, caseDetailsNode);
         }
 
         JsonNode oldCaseDetailsNode = getNode(node, "case_details_before");
         JsonNode oldCaseNode = getNode(oldCaseDetailsNode, "case_data");
 
         if (oldCaseNode != null) {
-            oldCcdResponse = deserializeCaseNode(oldCaseNode);
-            oldCcdResponse.setNotificationType(EventType.getNotificationById(getField(node, "event_id")));
+            oldCcdResponse = createCcdResponseFromNode(oldCaseNode, node, oldCaseDetailsNode);
         }
 
         return new CcdResponseWrapper(newCcdResponse, oldCcdResponse);
+    }
+
+    private CcdResponse createCcdResponseFromNode(JsonNode caseNode, JsonNode node, JsonNode caseDetailsNode) {
+        CcdResponse ccdResponse = deserializeCaseNode(caseNode);
+        ccdResponse.setNotificationType(EventType.getNotificationById(getField(node, "event_id")));
+        ccdResponse.setCaseId(getField(caseDetailsNode, "id"));
+        return ccdResponse;
     }
 
     public CcdResponse deserializeCaseNode(JsonNode caseNode) {

--- a/src/main/java/uk/gov/hmcts/sscs/domain/CcdResponse.java
+++ b/src/main/java/uk/gov/hmcts/sscs/domain/CcdResponse.java
@@ -6,6 +6,7 @@ import uk.gov.hmcts.sscs.domain.notify.EventType;
 
 public class CcdResponse {
 
+    private String caseId;
     private Benefit benefitType;
     private String caseReference;
     private Subscription appellantSubscription;
@@ -18,18 +19,28 @@ public class CcdResponse {
         //
     }
 
-    public CcdResponse(Benefit benefitType,
+    public CcdResponse(String caseId,
+                       Benefit benefitType,
                        String caseReference,
                        Subscription appellantSubscription,
                        Subscription supporterSubscription,
                        EventType notificationType,
                        List<Hearing> hearings) {
+        this.caseId = caseId;
         this.benefitType = benefitType;
         this.caseReference = caseReference;
         this.appellantSubscription = appellantSubscription;
         this.supporterSubscription = supporterSubscription;
         this.notificationType = notificationType;
         this.hearings = hearings;
+    }
+
+    public String getCaseId() {
+        return caseId;
+    }
+
+    public void setCaseId(String caseId) {
+        this.caseId = caseId;
     }
 
     public Benefit getBenefitType() {

--- a/src/main/java/uk/gov/hmcts/sscs/domain/reminder/Action.java
+++ b/src/main/java/uk/gov/hmcts/sscs/domain/reminder/Action.java
@@ -14,10 +14,10 @@ public class Action {
         this.method = "POST";
     }
 
-    private String createJsonBody(String appealNumber, String reminderType) {
+    private String createJsonBody(String caseId, String reminderType) {
         JSONObject json = new JSONObject();
-        json.put("appealNumber", appealNumber);
-        json.put("reminderType", reminderType);
+        json.put("caseId", caseId);
+        json.put("eventId", reminderType);
 
         return json.toString();
     }

--- a/src/main/java/uk/gov/hmcts/sscs/domain/reminder/Reminder.java
+++ b/src/main/java/uk/gov/hmcts/sscs/domain/reminder/Reminder.java
@@ -21,7 +21,7 @@ public class Reminder {
     public Reminder(CcdResponse ccdResponse, String callbackUrl) {
         String reminderType = findReminderType(ccdResponse.getNotificationType()).getId();
         this.name = NAME_PREFIX + reminderType;
-        this.action = new Action(ccdResponse.getAppellantSubscription().getAppealNumber(), reminderType, callbackUrl);
+        this.action = new Action(ccdResponse.getCaseId(), reminderType, callbackUrl);
         this.trigger = new Trigger(findReminderDate(ccdResponse));
     }
 

--- a/src/test/java/uk/gov/hmcts/sscs/deserialize/CcdResponseDeserializerTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/deserialize/CcdResponseDeserializerTest.java
@@ -194,7 +194,8 @@ public class CcdResponseDeserializerTest {
                             + "\"name\": \"Prudential House\",\"address\": {\"line1\": \"36 Dale Street\",\"line2\": \"\","
                             + "\"town\": \"Liverpool\",\"county\": \"Merseyside\",\"postcode\": \"L2 5UZ\"},"
                         + "\"googleMapLink\": \"https://www.google.com/theAddress\"}}}]"
-                + "}"
+                + "},"
+                + "\"id\": \"123456789\""
             + "},"
             + "\"event_id\": \"appealReceived\"}";
 
@@ -224,6 +225,7 @@ public class CcdResponseDeserializerTest {
         assertEquals("Merseyside", hearing.getVenueCounty());
         assertEquals("L2 5UZ", hearing.getVenuePostcode());
         assertEquals("https://www.google.com/theAddress", hearing.getVenueGoogleMapUrl());
+        assertEquals("123456789", ccdResponse.getCaseId());
     }
 
     @Test
@@ -234,13 +236,15 @@ public class CcdResponseDeserializerTest {
                 + "\"supporterSubscription\":{\"tya\":\"232929249492\",\"email\":\"supporter@live.co.uk\",\"mobile\":\"07925289702\",\"reason\":null,\"subscribeSms\":\"Yes\",\"subscribeEmail\":\"No\"}},"
                 + "\"caseReference\":\"SC/1234/23\",\"appeal\":{"
                 + "\"appellant\":{\"name\":{\"title\":\"Mr\",\"lastName\":\"Vasquez\",\"firstName\":\"Dexter\",\"middleName\":\"Ali Sosa\"}},"
-                + "\"supporter\":{\"name\":{\"title\":\"Mrs\",\"lastName\":\"Wilder\",\"firstName\":\"Amber\",\"middleName\":\"Clark Eaton\"}}}}},"
+                + "\"supporter\":{\"name\":{\"title\":\"Mrs\",\"lastName\":\"Wilder\",\"firstName\":\"Amber\",\"middleName\":\"Clark Eaton\"}}}},"
+                + "\"id\": \"123456789\"},"
                 + "\"case_details_before\":{\"case_data\":{\"subscriptions\":{"
                 + "\"appellantSubscription\":{\"tya\":\"123456\",\"email\":\"old@email.com\",\"mobile\":\"07543534345\",\"reason\":null,\"subscribeSms\":\"No\",\"subscribeEmail\":\"Yes\"},"
                 + "\"supporterSubscription\":{\"tya\":\"232929249492\",\"email\":\"supporter@gmail.co.uk\",\"mobile\":\"07925267702\",\"reason\":null,\"subscribeSms\":\"Yes\",\"subscribeEmail\":\"No\"}},"
                 + "\"caseReference\":\"SC/5432/89\",\"appeal\":{"
                 + "\"appellant\":{\"name\":{\"title\":\"Mr\",\"lastName\":\"Smith\",\"firstName\":\"Jeremy\",\"middleName\":\"Rupert\"}},"
-                + "\"supporter\":{\"name\":{\"title\":\"Mr\",\"lastName\":\"Redknapp\",\"firstName\":\"Harry\",\"middleName\":\"Winston\"}}}}},"
+                + "\"supporter\":{\"name\":{\"title\":\"Mr\",\"lastName\":\"Redknapp\",\"firstName\":\"Harry\",\"middleName\":\"Winston\"}}}},"
+                + "\"id\": \"523456789\"},"
                 + "\"event_id\": \"appealReceived\"\n}";
 
         CcdResponseWrapper wrapper = mapper.readValue(json, CcdResponseWrapper.class);
@@ -262,6 +266,7 @@ public class CcdResponseDeserializerTest {
         assertTrue(newCcdResponse.getSupporterSubscription().isSubscribeSms());
         assertFalse(newCcdResponse.getSupporterSubscription().isSubscribeEmail());
         assertEquals("SC/1234/23", newCcdResponse.getCaseReference());
+        assertEquals("123456789", newCcdResponse.getCaseId());
 
         CcdResponse oldCcdResponse = wrapper.getOldCcdResponse();
 
@@ -280,6 +285,7 @@ public class CcdResponseDeserializerTest {
         assertTrue(oldCcdResponse.getSupporterSubscription().isSubscribeSms());
         assertFalse(oldCcdResponse.getSupporterSubscription().isSubscribeEmail());
         assertEquals("SC/5432/89", oldCcdResponse.getCaseReference());
+        assertEquals("523456789", oldCcdResponse.getCaseId());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/sscs/factory/NotificationFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/factory/NotificationFactoryTest.java
@@ -26,6 +26,8 @@ import uk.gov.hmcts.sscs.service.MessageAuthenticationServiceImpl;
 
 public class NotificationFactoryTest {
 
+    private static final String CASE_ID = "54321";
+
     private NotificationFactory factory;
 
     private CcdResponseWrapper wrapper;
@@ -49,7 +51,7 @@ public class NotificationFactoryTest {
         personalisation = new Personalisation(config, macService);
         subscriptionPersonalisation = new SubscriptionPersonalisation(config, macService);
         factory = new NotificationFactory(personalisationFactory);
-        wrapper = new CcdResponseWrapper(new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
+        wrapper = new CcdResponseWrapper(new CcdResponse(CASE_ID, PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
                 "ABC","test@testing.com", "07985858594", true, false), null, APPEAL_RECEIVED, null), null);
         when(config.getHmctsPhoneNumber()).thenReturn("01234543225");
         when(config.getManageEmailsLink()).thenReturn(new Link("http://manageemails.com/mac"));
@@ -77,9 +79,9 @@ public class NotificationFactoryTest {
         when(personalisationFactory.apply(SUBSCRIPTION_UPDATED)).thenReturn(subscriptionPersonalisation);
         when(config.getTemplate(SUBSCRIPTION_UPDATED.getId(), SUBSCRIPTION_CREATED.getId())).thenReturn(new Template(null, "123"));
 
-        wrapper = new CcdResponseWrapper(new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
+        wrapper = new CcdResponseWrapper(new CcdResponse(CASE_ID, PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
                 "ABC", "test@testing.com", "07985858594", true, false), null, SUBSCRIPTION_UPDATED, null),
-                new CcdResponse(PIP, "SC/1234/5", new Subscription("Ronnie", "Scott", "Mr", "ABC",
+                new CcdResponse(CASE_ID, PIP, "SC/1234/5", new Subscription("Ronnie", "Scott", "Mr", "ABC",
                         "test@testing.com", "07985858594", false, false), null, SUBSCRIPTION_UPDATED, null));
 
         Notification result = factory.create(wrapper);
@@ -92,10 +94,10 @@ public class NotificationFactoryTest {
         when(personalisationFactory.apply(SUBSCRIPTION_UPDATED)).thenReturn(subscriptionPersonalisation);
         when(config.getTemplate(SUBSCRIPTION_UPDATED.getId(), SUBSCRIPTION_UPDATED.getId())).thenReturn(new Template(null, "123"));
 
-        wrapper = new CcdResponseWrapper(new CcdResponse(PIP, "SC/1234/5", new Subscription("Ronnie", "Scott",
+        wrapper = new CcdResponseWrapper(new CcdResponse(CASE_ID, PIP, "SC/1234/5", new Subscription("Ronnie", "Scott",
                 "Mr", "ABC",
                 "test@testing.com", "07985858594", true, false), null, SUBSCRIPTION_UPDATED, null),
-                new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr", "ABC",
+                new CcdResponse(CASE_ID, PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr", "ABC",
                         "test@testing.com", "07985858594", true, false), null, SUBSCRIPTION_UPDATED, null));
 
         Notification result = factory.create(wrapper);
@@ -108,11 +110,11 @@ public class NotificationFactoryTest {
         when(personalisationFactory.apply(SUBSCRIPTION_UPDATED)).thenReturn(subscriptionPersonalisation);
         when(config.getTemplate(APPEAL_RECEIVED.getId(), SUBSCRIPTION_CREATED.getId())).thenReturn(new Template("123", null));
 
-        CcdResponse newResponse = new CcdResponse(PIP, "SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
+        CcdResponse newResponse = new CcdResponse(CASE_ID, PIP, "SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
                 "ABC",
                 "test@testing.com", "07985858594", true, true), null, SUBSCRIPTION_UPDATED, null);
 
-        CcdResponse oldResponse = new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
+        CcdResponse oldResponse = new CcdResponse(CASE_ID, PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
                 "ABC",
                 "test@testing.com", "07985858594", false, false), null, SUBSCRIPTION_UPDATED, null);
 
@@ -134,11 +136,11 @@ public class NotificationFactoryTest {
         when(personalisationFactory.apply(SUBSCRIPTION_UPDATED)).thenReturn(subscriptionPersonalisation);
         when(config.getTemplate(DO_NOT_SEND.getId(), SUBSCRIPTION_CREATED.getId())).thenReturn(new Template(null, null));
 
-        CcdResponse newResponse = new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
+        CcdResponse newResponse = new CcdResponse(CASE_ID, PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
                 "ABC",
                 "test@testing.com", "07985858594", true, true), null, SUBSCRIPTION_UPDATED, null);
 
-        CcdResponse oldResponse = new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
+        CcdResponse oldResponse = new CcdResponse(CASE_ID, PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
                 "ABC",
                 "test@testing.com", "07985858594", false, true), null, SUBSCRIPTION_UPDATED, null);
 
@@ -161,11 +163,11 @@ public class NotificationFactoryTest {
         when(personalisationFactory.apply(SUBSCRIPTION_UPDATED)).thenReturn(subscriptionPersonalisation);
         when(config.getTemplate(SUBSCRIPTION_UPDATED.getId(), SUBSCRIPTION_CREATED.getId())).thenReturn(new Template("123", null));
 
-        CcdResponse newResponse = new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
+        CcdResponse newResponse = new CcdResponse(CASE_ID, PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
                 "ABC",
                 "changed@testing.com", "07985858594", true, true), null, SUBSCRIPTION_UPDATED, null);
 
-        CcdResponse oldResponse = new CcdResponse(PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
+        CcdResponse oldResponse = new CcdResponse(CASE_ID, PIP,"SC/1234/5", new Subscription("Ronnie", "Scott", "Mr",
                 "ABC",
                 "test@testing.com", "07985858594", false, true), null, SUBSCRIPTION_UPDATED, null);
 

--- a/src/test/java/uk/gov/hmcts/sscs/personalisation/PersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/personalisation/PersonalisationTest.java
@@ -27,6 +27,8 @@ import uk.gov.hmcts.sscs.service.MessageAuthenticationServiceImpl;
 
 public class PersonalisationTest {
 
+    private static final String CASE_ID = "54321";
+
     public Personalisation personalisation;
 
     @Mock
@@ -60,7 +62,7 @@ public class PersonalisationTest {
         Subscription appellantSubscription = new Subscription("Harry", "Kane", "Mr", "GLSCRR", "test@email.com",
                 "07983495065", true, false);
 
-        CcdResponse response = new CcdResponse(PIP, "1234", appellantSubscription, null, APPEAL_RECEIVED, null);
+        CcdResponse response = new CcdResponse(CASE_ID, PIP, "1234", appellantSubscription, null, APPEAL_RECEIVED, null);
         response.setEvents(new ArrayList() {{
                 add(event);
             }
@@ -89,7 +91,7 @@ public class PersonalisationTest {
     public void setAppealReceivedEventData() {
         Event event = new Event(dateTime, APPEAL_RECEIVED);
 
-        CcdResponse response = new CcdResponse(PIP,"1234", null, null, APPEAL_RECEIVED, null);
+        CcdResponse response = new CcdResponse(CASE_ID, PIP,"1234", null, null, APPEAL_RECEIVED, null);
 
         response.setEvents(new ArrayList() {{
                 add(event);
@@ -106,7 +108,7 @@ public class PersonalisationTest {
     public void setEvidenceReceivedEventData() {
         Event event = new Event(dateTime, EVIDENCE_RECEIVED);
 
-        CcdResponse response = new CcdResponse(PIP,"1234", null, null, EVIDENCE_RECEIVED, null);
+        CcdResponse response = new CcdResponse(CASE_ID, PIP,"1234", null, null, EVIDENCE_RECEIVED, null);
 
         response.setEvents(new ArrayList() {{
                 add(event);
@@ -126,7 +128,7 @@ public class PersonalisationTest {
         Subscription appellantSubscription = new Subscription("Harry", "Kane", "Mr", "GLSCRR", "test@email.com",
                 "07983495065", true, false);
 
-        CcdResponse response = new CcdResponse(PIP, "1234", appellantSubscription, null, EVIDENCE_RECEIVED, null);
+        CcdResponse response = new CcdResponse(CASE_ID, PIP, "1234", appellantSubscription, null, EVIDENCE_RECEIVED, null);
         response.setEvents(new ArrayList() {{
                 add(event1);
                 add(event2);
@@ -142,7 +144,7 @@ public class PersonalisationTest {
     public void setPostponementEventData() {
         Event event = new Event(dateTime, POSTPONEMENT);
 
-        CcdResponse response = new CcdResponse(PIP,"1234", null, null, POSTPONEMENT, null);
+        CcdResponse response = new CcdResponse(CASE_ID, PIP,"1234", null, null, POSTPONEMENT, null);
 
         response.setEvents(new ArrayList() {{
                 add(event);
@@ -156,7 +158,7 @@ public class PersonalisationTest {
 
     @Test
     public void handleNullEventWhenPopulatingEventData() {
-        CcdResponse response = new CcdResponse(PIP,"1234", null, null, POSTPONEMENT, null);
+        CcdResponse response = new CcdResponse(CASE_ID, PIP,"1234", null, null, POSTPONEMENT, null);
 
         Map<String, String> result = personalisation.setEventData(new HashMap<>(), response);
 
@@ -165,7 +167,7 @@ public class PersonalisationTest {
 
     @Test
     public void handleEmptyEventsWhenPopulatingEventData() {
-        CcdResponse response = new CcdResponse(PIP,"1234", null, null, POSTPONEMENT, null);
+        CcdResponse response = new CcdResponse(CASE_ID, PIP,"1234", null, null, POSTPONEMENT, null);
 
         response.setEvents(new ArrayList());
 

--- a/src/test/java/uk/gov/hmcts/sscs/personalisation/SubscriptionPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/personalisation/SubscriptionPersonalisationTest.java
@@ -60,8 +60,8 @@ public class SubscriptionPersonalisationTest {
         oldAppellantSubscription = new Subscription("Harry", "Kane", "Mr", "GLSCRR", "test@email.com",
                 "07983495065", false, false);
 
-        newCcdResponse = new CcdResponse(PIP,"1234", newAppellantSubscription, null, SUBSCRIPTION_UPDATED, null);
-        oldCcdResponse = new CcdResponse(PIP,"5432", oldAppellantSubscription, null, SUBSCRIPTION_UPDATED, null);
+        newCcdResponse = new CcdResponse("54321", PIP,"1234", newAppellantSubscription, null, SUBSCRIPTION_UPDATED, null);
+        oldCcdResponse = new CcdResponse("54321", PIP,"5432", oldAppellantSubscription, null, SUBSCRIPTION_UPDATED, null);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/sscs/service/ReminderServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/service/ReminderServiceTest.java
@@ -20,7 +20,6 @@ import org.mockito.Mock;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.sscs.client.RestClient;
 import uk.gov.hmcts.sscs.domain.CcdResponse;
-import uk.gov.hmcts.sscs.domain.Subscription;
 import uk.gov.hmcts.sscs.domain.notify.Event;
 import uk.gov.hmcts.sscs.domain.notify.EventType;
 
@@ -40,9 +39,7 @@ public class ReminderServiceTest {
     @Test
     public void createReminderFromCcdResponse() throws Exception {
         CcdResponse ccdResponse = new CcdResponse();
-        Subscription subscription = new Subscription();
-        subscription.setAppealNumber("123456");
-        ccdResponse.setAppellantSubscription(subscription);
+        ccdResponse.setCaseId("123456");
         ccdResponse.setNotificationType(EventType.DWP_RESPONSE_RECEIVED);
         ZonedDateTime dateTime = ZonedDateTime.of(LocalDate.of(2018, 4, 1), LocalTime.of(0, 0), ZoneId.of(ZONE_ID));
 
@@ -62,8 +59,8 @@ public class ReminderServiceTest {
         JSONObject j = (JSONObject) captor.getValue();
 
         JSONObject expectedBodyJson = new JSONObject();
-        expectedBodyJson.put("appealNumber", "123456");
-        expectedBodyJson.put("reminderType", "evidenceReminder");
+        expectedBodyJson.put("caseId", "123456");
+        expectedBodyJson.put("eventId", "evidenceReminder");
 
         assertEquals("SSCS_evidenceReminder", j.get("name"));
         assertEquals("www.test.com", ((JSONObject) j.get("action")).get("url"));


### PR DESCRIPTION
- When deserialising case from CCD extract the caseId so that this can be used be Reminders
- Change field names for Reminder object to match Tribunals API