### PR TITLE
Fix appeal created email issues

### DIFF
--- a/src/main/java/uk/gov/hmcts/sscs/deserialize/CcdResponseWrapperDeserializer.java
+++ b/src/main/java/uk/gov/hmcts/sscs/deserialize/CcdResponseWrapperDeserializer.java
@@ -246,13 +246,16 @@ public class CcdResponseWrapperDeserializer extends StdDeserializer<CcdResponseW
     public void deserializeRepresentativeReasons(JsonNode appealReasonsNode, Appeal appeal) {
         final JsonNode repNode = appealReasonsNode.get("rep");
 
-        Name name = deserializeNameJson(repNode);
-        Address address = deserializeAddressJson(repNode);
-        Contact contact = deserializeContactJson(repNode);
-        String organisation = getField(repNode, "organisation");
+        String hasRepresentative = getField(repNode, "hasRepresentative");
+        if (hasRepresentative != null && hasRepresentative.toLowerCase().equals("yes")) {
+            Name name = deserializeNameJson(repNode);
+            Address address = deserializeAddressJson(repNode);
+            Contact contact = deserializeContactJson(repNode);
+            String organisation = getField(repNode, "organisation");
 
-        appeal.setRep(Representative.builder()
-                .name(name).address(address).contact(contact).organisation(organisation).build());
+            appeal.setRep(Representative.builder()
+                    .name(name).address(address).contact(contact).organisation(organisation).build());
+        }
     }
 
     public void deserializeSubscriptionJson(JsonNode subscriptionsNode, CcdResponse ccdResponse) {

--- a/src/main/java/uk/gov/hmcts/sscs/personalisation/SyaAppealCreatedPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/sscs/personalisation/SyaAppealCreatedPersonalisation.java
@@ -188,11 +188,11 @@ public class SyaAppealCreatedPersonalisation extends Personalisation {
     }
 
     private String buildHearingArrangements(HearingOptions hearingOptions) {
-        String languagueInterpreterRequired = convertBooleanToRequiredText(hearingOptions.getLanguageInterpreter().toLowerCase().equals("yes") ? true : false);
+        String languageInterpreterRequired = convertBooleanToRequiredText(hearingOptions.getLanguageInterpreter() != null && hearingOptions.getLanguageInterpreter().toLowerCase().equals("yes") ? true : false);
 
         return new StringBuilder()
                 .append("Language interpreter: ")
-                .append(languagueInterpreterRequired + "\n\n")
+                .append(languageInterpreterRequired + "\n\n")
                 .append("Sign interpreter: ")
                 .append(convertBooleanToRequiredText(findHearingArrangement("signLanguageInterpreter", hearingOptions.getArrangements())) + "\n\n")
                 .append("Hearing loop: ")

--- a/src/main/java/uk/gov/hmcts/sscs/personalisation/SyaAppealCreatedPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/sscs/personalisation/SyaAppealCreatedPersonalisation.java
@@ -4,9 +4,11 @@ import static uk.gov.hmcts.sscs.config.AppConstants.*;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.sscs.domain.*;
 
@@ -35,14 +37,20 @@ public class SyaAppealCreatedPersonalisation extends Personalisation {
     }
 
     private String buildMrnDetails(MrnDetails mrnDetails) {
-        return new StringBuilder()
-                .append("Date of MRN: ")
-                .append(mrnDetails.getMrnDate() + "\n\n")
-                .append("Reason for late appeal: ")
-                .append(mrnDetails.getMrnLateReason() + "\n\n")
-                .append("Reason for no MRN: ")
-                .append(mrnDetails.getMrnMissingReason())
-                .toString();
+
+        List<String> details = new ArrayList<>();
+
+        if (mrnDetails.getMrnDate() != null) {
+            details.add("Date of MRN: " + mrnDetails.getMrnDate());
+        }
+        if (mrnDetails.getMrnLateReason() != null) {
+            details.add("Reason for late appeal: " + mrnDetails.getMrnLateReason());
+        }
+        if (mrnDetails.getMrnMissingReason() != null) {
+            details.add("Reason for no MRN: " + mrnDetails.getMrnMissingReason());
+        }
+
+        return StringUtils.join(details.toArray(),"\n\n").toString();
     }
 
     public Map<String, String> setYourDetails(Map<String, String> personalisation, CcdResponse ccdResponse) {

--- a/src/test/java/uk/gov/hmcts/sscs/personalisation/SyaAppealCreatedPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/personalisation/SyaAppealCreatedPersonalisationTest.java
@@ -350,12 +350,32 @@ public class SyaAppealCreatedPersonalisationTest {
     }
 
     @Test
-    public void givenASyaAppealWithNoHearingArrangements_setHearingArrangementsForTemplate() {
+    public void givenASyaAppealWithNoLanguageInterpreter_setHearingArrangementsForTemplate() {
 
         response = CcdResponse.builder()
                 .caseId(CASE_ID).caseReference("SC/1234/5")
                 .appeal(Appeal.builder().hearingOptions(HearingOptions.builder()
                         .languageInterpreter("No")
+                        .build()).build())
+                .notificationType(SYA_APPEAL_CREATED)
+                .build();
+
+        Map<String, String> result = personalisation.setHearingArrangementDetails(new HashMap<>(), response);
+
+        assertEquals("Language interpreter: Not required\n"
+                        + "\nSign interpreter: Not required\n"
+                        + "\nHearing loop: Not required\n"
+                        + "\nDisabled access: Not required\n"
+                        + "\nAny other arrangements: Not required",
+                result.get(HEARING_ARRANGEMENT_DETAILS_LITERAL));
+    }
+
+    @Test
+    public void givenASyaAppealWithNoHearingArrangements_setHearingArrangementsForTemplate() {
+
+        response = CcdResponse.builder()
+                .caseId(CASE_ID).caseReference("SC/1234/5")
+                .appeal(Appeal.builder().hearingOptions(HearingOptions.builder()
                         .build()).build())
                 .notificationType(SYA_APPEAL_CREATED)
                 .build();

--- a/src/test/java/uk/gov/hmcts/sscs/personalisation/SyaAppealCreatedPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/personalisation/SyaAppealCreatedPersonalisationTest.java
@@ -48,6 +48,22 @@ public class SyaAppealCreatedPersonalisationTest {
     }
 
     @Test
+    public void givenASyaAppealCreated_setMrnDetailsForTemplateWhenReasonForNoMrnMissing() {
+        response = CcdResponse.builder()
+                .caseId(CASE_ID).caseReference("SC/1234/5")
+                .appeal(Appeal.builder().benefitType(BenefitType.builder().code("PIP").build())
+                        .mrnDetails(MrnDetails.builder().mrnDate("3 May 2018").mrnLateReason("My train was cancelled.").build()).build())
+                .notificationType(SYA_APPEAL_CREATED)
+                .build();
+
+        Map<String, String> result = personalisation.setMrnDetails(new HashMap<>(), response);
+
+        assertEquals("Date of MRN: 3 May 2018\n"
+                        + "\nReason for late appeal: My train was cancelled.",
+                result.get(MRN_DETAILS_LITERAL));
+    }
+
+    @Test
     public void givenASyaAppealCreated_setYourDetailsForTemplate() {
         response = CcdResponse.builder()
                 .caseId(CASE_ID).caseReference("SC/1234/5")


### PR DESCRIPTION
Issues fixed: 
- Language interpreter threw NPE when missing
- Missing representative set fields to null in the email
- Missing MRN details set fields to null in the email 