### PR TITLE
Switch appeal reason and description

### DIFF
--- a/src/main/java/uk/gov/hmcts/sscs/personalisation/SyaAppealCreatedPersonalisation.java
+++ b/src/main/java/uk/gov/hmcts/sscs/personalisation/SyaAppealCreatedPersonalisation.java
@@ -136,9 +136,9 @@ public class SyaAppealCreatedPersonalisation extends Personalisation {
         if (appealReasons.getReasons() != null && appealReasons.getReasons().size() > 0) {
             for (AppealReason reason : appealReasons.getReasons()) {
                 appealReasonsBuilder.append("What you disagree with: ")
-                        .append(reason.getValue().getReason() + "\n\n")
+                        .append(reason.getValue().getDescription() + "\n\n")
                         .append("Why you disagree with it: ")
-                        .append(reason.getValue().getDescription() + "\n\n");
+                        .append(reason.getValue().getReason() + "\n\n");
             }
         }
 

--- a/src/test/java/uk/gov/hmcts/sscs/personalisation/SyaAppealCreatedPersonalisationTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/personalisation/SyaAppealCreatedPersonalisationTest.java
@@ -216,7 +216,7 @@ public class SyaAppealCreatedPersonalisationTest {
     @Test
     public void givenASyaAppealWithOneReasonForAppealing_setReasonForAppealingDetailsForTemplate() {
         List<AppealReason> appealReasonList = new ArrayList<>();
-        AppealReason reason = AppealReason.builder().value(AppealReasonDetails.builder().reason("I want to appeal").description("Because I do").build()).build();
+        AppealReason reason = AppealReason.builder().value(AppealReasonDetails.builder().description("I want to appeal").reason("Because I do").build()).build();
         appealReasonList.add(reason);
 
         response = CcdResponse.builder()
@@ -237,8 +237,8 @@ public class SyaAppealCreatedPersonalisationTest {
     @Test
     public void givenASyaAppealWithMultipleReasonsForAppealing_setReasonForAppealingDetailsForTemplate() {
         List<AppealReason> appealReasonList = new ArrayList<>();
-        AppealReason reason1 = AppealReason.builder().value(AppealReasonDetails.builder().reason("I want to appeal").description("Because I do").build()).build();
-        AppealReason reason2 = AppealReason.builder().value(AppealReasonDetails.builder().reason("I want to appeal again").description("I'm in the mood").build()).build();
+        AppealReason reason1 = AppealReason.builder().value(AppealReasonDetails.builder().description("I want to appeal").reason("Because I do").build()).build();
+        AppealReason reason2 = AppealReason.builder().value(AppealReasonDetails.builder().description("I want to appeal again").reason("I'm in the mood").build()).build();
         appealReasonList.add(reason1);
         appealReasonList.add(reason2);
 


### PR DESCRIPTION
The 'reason for appeal' and 'appeal description' appeared in the wrong order on the Appeal Created summary email, so just switched them around 