### PR TITLE
SSCS-3771 Fix for past hearing booked notifications sent

### DIFF
--- a/src/IntegrationTests/java/uk/gov/hmcts/sscs/tya/HearingHoldingReminderIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/sscs/tya/HearingHoldingReminderIt.java
@@ -6,6 +6,7 @@ import static helper.IntegrationTestHelper.getRequestWithAuthHeader;
 import helper.IntegrationTestHelper;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import javax.servlet.http.HttpServletResponse;
@@ -136,6 +137,7 @@ public class HearingHoldingReminderIt {
 
         ccdResponseJson = ccdResponseJson.replace("appealReceived", event);
         ccdResponseJson = ccdResponseJson.replace("2017-05-24T14:01:18.243", "2048-05-24T14:01:18.243");
+        ccdResponseJson = ccdResponseJson.replace("2018-01-12", LocalDate.now().plusDays(2).toString());
 
         HttpServletResponse sendResponse = getResponse(getRequestWithAuthHeader(ccdResponseJson));
         assertHttpStatus(sendResponse, HttpStatus.OK);

--- a/src/e2e/java/uk/gov/hmcts/sscs/functional/AbstractFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/sscs/functional/AbstractFunctionalTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -176,8 +177,7 @@ public abstract class AbstractFunctionalTest {
         String path = getClass().getClassLoader().getResource(resource).getFile();
         String json = FileUtils.readFileToString(new File(path), StandardCharsets.UTF_8.name());
 
-        json = json.replace("12345656789", caseId.toString());
-        json = json.replace("SC022/14/12423", caseReference);
+        json = updateJson(json, eventType);
 
         RestAssured.useRelaxedHTTPSValidation();
         RestAssured
@@ -189,6 +189,17 @@ public abstract class AbstractFunctionalTest {
                 .post(callbackUrl)
                 .then()
                 .statusCode(HttpStatus.OK.value());
+    }
+
+    private String updateJson(String json, EventType eventType) {
+        json = json.replace("12345656789", caseId.toString());
+        json = json.replace("SC022/14/12423", caseReference);
+
+        if (eventType.equals(EventType.HEARING_BOOKED)) {
+            json = json.replace("2016-01-01", LocalDate.now().toString());
+        }
+
+        return json;
     }
 
     protected void triggerEvent(EventType eventType) {

--- a/src/e2e/java/uk/gov/hmcts/sscs/functional/ReminderNotificationsFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/sscs/functional/ReminderNotificationsFunctionalTest.java
@@ -1,9 +1,12 @@
 package uk.gov.hmcts.sscs.functional;
 
 import static uk.gov.hmcts.sscs.CcdResponseUtils.addHearing;
+import static uk.gov.hmcts.sscs.config.AppConstants.RESPONSE_DATE_FORMAT;
 import static uk.gov.hmcts.sscs.domain.notify.EventType.*;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
@@ -236,7 +239,7 @@ public class ReminderNotificationsFunctionalTest extends AbstractFunctionalTest 
     @Test
     public void shouldSendNotificationsWhenHearingBookedEventIsReceived() throws IOException, NotificationClientException {
 
-        addHearing(caseData);
+        addHearing(caseData, 0);
         triggerEvent(HEARING_BOOKED);
         simulateCcdCallback(HEARING_BOOKED);
 
@@ -249,14 +252,17 @@ public class ReminderNotificationsFunctionalTest extends AbstractFunctionalTest 
             );
 
         assertNotificationSubjectContains(notifications, hearingReminderEmailTemplateId, "ESA");
+
+        String formattedString = LocalDate.now().format(DateTimeFormatter.ofPattern(RESPONSE_DATE_FORMAT));
+
         assertNotificationBodyContains(
             notifications,
             hearingReminderEmailTemplateId,
             caseReference,
             "ESA",
             "reminder",
-            "01 January 2016",
-            "12:00 PM",
+            formattedString,
+            "11:59 PM",
             "AB12 0HN",
             "/abouthearing"
         );
@@ -266,8 +272,8 @@ public class ReminderNotificationsFunctionalTest extends AbstractFunctionalTest 
             hearingReminderSmsTemplateId,
             "ESA",
             "reminder",
-            "01 January 2016",
-            "12:00 PM",
+            formattedString,
+            "11:59 PM",
             "AB12 0HN",
             "/abouthearing"
         );

--- a/src/e2e/resources/hearingBookedCallback.json
+++ b/src/e2e/resources/hearingBookedCallback.json
@@ -60,8 +60,8 @@
           "id": "609523de-ba0a-45e7-8f0b-af3f82ab347c",
           "value": {
             "adjourned": null,
-            "hearingDate": "2016-01-01",
-            "time": "12:00",
+            "hearingDate": "2048-01-01",
+            "time": "23:59",
             "venue": {
               "address": {
                 "county": "Aberdeenshire",

--- a/src/main/java/uk/gov/hmcts/sscs/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/sscs/service/NotificationService.java
@@ -20,12 +20,15 @@ public class NotificationService {
     private final NotificationSender notificationSender;
     private final NotificationFactory factory;
     private final ReminderService reminderService;
+    private final NotificationValidService notificationValidService;
 
     @Autowired
-    public NotificationService(NotificationSender notificationSender, NotificationFactory factory, ReminderService reminderService) {
+    public NotificationService(NotificationSender notificationSender, NotificationFactory factory, ReminderService reminderService,
+                               NotificationValidService notificationValidService) {
         this.factory = factory;
         this.notificationSender = notificationSender;
         this.reminderService = reminderService;
+        this.notificationValidService = notificationValidService;
     }
 
     public void createAndSendNotification(CcdResponseWrapper responseWrapper) {
@@ -36,7 +39,8 @@ public class NotificationService {
 
         LOG.info("Notification event triggered {} for case id {}", notificationEventType, caseId);
 
-        if (appellantSubscription != null && appellantSubscription.doesCaseHaveSubscriptions()) {
+        if (appellantSubscription != null && appellantSubscription.doesCaseHaveSubscriptions() && notificationValidService.isNotificationStillValidToSend(
+                responseWrapper.getNewCcdResponse().getHearings(), responseWrapper.getNewCcdResponse().getNotificationType())) {
 
             Notification notification = factory.create(responseWrapper);
 

--- a/src/main/java/uk/gov/hmcts/sscs/service/NotificationValidService.java
+++ b/src/main/java/uk/gov/hmcts/sscs/service/NotificationValidService.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.sscs.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.sscs.domain.Hearing;
+import uk.gov.hmcts.sscs.domain.notify.EventType;
+
+@Service
+public class NotificationValidService {
+
+    public Boolean isNotificationStillValidToSend(List<Hearing> hearings, EventType eventType) {
+        switch (eventType) {
+            case HEARING_BOOKED: return checkHearingIsInFuture(hearings);
+            case HEARING_REMINDER: return checkHearingIsInFuture(hearings);
+            default: return true;
+        }
+    }
+
+    private Boolean checkHearingIsInFuture(List<Hearing> hearings) {
+        if (hearings != null && !hearings.isEmpty()) {
+
+            Hearing latestHearing = hearings.get(0);
+            LocalDateTime hearingDateTime = latestHearing.getValue().getHearingDateTime();
+            return hearingDateTime.isAfter(LocalDateTime.now());
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/sscs/CcdResponseUtils.java
+++ b/src/test/java/uk/gov/hmcts/sscs/CcdResponseUtils.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.sscs;
 
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -185,10 +186,10 @@ public final class CcdResponseUtils {
         response.setEvidence(evidence);
     }
 
-    public static void addHearing(CcdResponse response) {
+    public static List<Hearing> addHearing(CcdResponse response, Integer hearingDaysFromNow) {
         Hearing hearing = Hearing.builder().value(HearingDetails.builder()
-            .hearingDate("2016-01-01")
-            .time("12:00")
+            .hearingDate(LocalDate.now().plusDays(hearingDaysFromNow).toString())
+            .time("23:59")
             .venue(Venue.builder()
                 .name("The venue")
                 .address(Address.builder()
@@ -202,8 +203,9 @@ public final class CcdResponseUtils {
 
         List<Hearing> hearingsList = new ArrayList<>();
         hearingsList.add(hearing);
-
         response.setHearings(hearingsList);
+
+        return hearingsList;
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/sscs/service/NotificationValidServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/service/NotificationValidServiceTest.java
@@ -1,0 +1,58 @@
+package uk.gov.hmcts.sscs.service;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.hmcts.sscs.CcdResponseUtils;
+import uk.gov.hmcts.sscs.domain.CcdResponse;
+import uk.gov.hmcts.sscs.domain.notify.EventType;
+
+public class NotificationValidServiceTest {
+
+    private NotificationValidService notificationValidService;
+    private CcdResponse ccdResponse;
+
+    @Before
+    public void setup() {
+        notificationValidService = new NotificationValidService();
+        ccdResponse = CcdResponse.builder().build();
+    }
+
+    @Test
+    public void givenHearingIsInFutureAndEventIsHearingBooked_thenNotificationIsStillValidToSend() {
+        assertTrue(
+            notificationValidService.isNotificationStillValidToSend(CcdResponseUtils.addHearing(ccdResponse, 1), EventType.HEARING_BOOKED)
+        );
+    }
+
+    @Test
+    public void givenHearingIsInFutureAndEventIsHearingReminder_thenNotificationIsStillValidToSend() {
+        assertTrue(
+            notificationValidService.isNotificationStillValidToSend(CcdResponseUtils.addHearing(ccdResponse, 1), EventType.HEARING_REMINDER)
+        );
+    }
+
+    @Test
+    public void givenHearingIsInPastAndEventIsHearingBooked_thenNotificationIsNotValidToSend() {
+        assertFalse(
+            notificationValidService.isNotificationStillValidToSend(CcdResponseUtils.addHearing(ccdResponse, -1), EventType.HEARING_BOOKED)
+        );
+    }
+
+    @Test
+    public void givenHearingIsInPastAndEventIsHearingReminder_thenNotificationIsNotValidToSend() {
+        assertFalse(
+            notificationValidService.isNotificationStillValidToSend(CcdResponseUtils.addHearing(ccdResponse, -1), EventType.HEARING_REMINDER)
+        );
+    }
+
+    @Test
+    public void givenCaseDoesNotContainHearingAndEventIsHearingBooked_thenNotificationIsNotValidToSend() {
+        assertFalse(
+            notificationValidService.isNotificationStillValidToSend(null, EventType.HEARING_BOOKED)
+        );
+    }
+
+}


### PR DESCRIPTION
- Notifications were still being sent for hearings that had already happened. This fixes this